### PR TITLE
refactor: make logger fields private

### DIFF
--- a/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    public static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {

--- a/src/main/java/com/management/services/PlayerService.java
+++ b/src/main/java/com/management/services/PlayerService.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 @Service
 public class PlayerService {
-    public static final Logger logger = LoggerFactory.getLogger(PlayerService.class);
+    private static final Logger logger = LoggerFactory.getLogger(PlayerService.class);
     private static final String PLAYER_NOT_FOUND = "Player not found";
     private static final String PLAYER_ID = " Player ID: ";
     @Autowired


### PR DESCRIPTION
## Summary

This PR makes the logger fields in:

- `PlayerService`
- `GlobalExceptionHandler`

private instead of public.

## Why

The loggers are only used inside their own classes, so the fields do not need to be publicly accessible.

## Verification

- `git diff --check` passed
- `mvn verify` passed with all 5 tests passing and 0 failures/errors.

Closes #31