### PR TITLE
Remove unused player sync endpoint

### DIFF
--- a/src/main/java/com/management/controllers/KumiteGameController.java
+++ b/src/main/java/com/management/controllers/KumiteGameController.java
@@ -68,14 +68,6 @@ public class KumiteGameController {
         return ResponseEntity.ok("Foul removed successfully.");
     }
 
-    @PutMapping("/{gameId}/update-player/{color}")
-    public ResponseEntity<KumiteGame> updatePlayerInKumiteGame(
-            @PathVariable String gameId,
-            @PathVariable String color) {
-        KumiteGame updatedGame = kumiteGameService.updateKumiteGamePlayers(gameId, color);
-        return ResponseEntity.ok(updatedGame);
-    }
-
     @PutMapping("/{gameId}/update-winner/{color}")
     public ResponseEntity<KumiteGame> updateKumiteGameWinner(
             @PathVariable String gameId,


### PR DESCRIPTION
## Summary

- Removed the unused public player sync endpoint from `KumiteGameController`
- Kept the internal service method unchanged
- Verified the project still passes all tests

Fixes #50