### PR TITLE
chore: add Spring Boot Actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Summary
Adds Spring Boot Actuator for application health monitoring.

## Changes
- Added spring-boot-starter-actuator dependency.
- Enables the standard Actuator health endpoint.
- Allows Spring Boot to provide MongoDB health information.

## Testing
- Maven tests pass successfully.

Closes #56