### PR TITLE
chore: make mvn verify the single test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,9 @@ on:
     branches: [main]
   pull_request:
 
-# Least privilege. `pull_request` already runs fork code without repository
-# secrets and with a read-only token; this pins it explicitly.
-# Never switch this workflow to `pull_request_target` -- that trigger grants
-# secrets to code from forks.
 permissions:
   contents: read
 
-# A new push to a branch cancels the run still in flight for it.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -40,7 +35,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports
-          path: '**/target/surefire-reports/*'
+          name: test-reports
+          path: |
+            **/target/surefire-reports/*
+            **/target/failsafe-reports/*
           if-no-files-found: ignore
           retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,9 @@ No transition guard is currently enforced — every transition is permitted by t
 - Spring Boot 3.2.3, Maven, embedded Tomcat
 - MongoDB 7 in Docker — `localhost:27017`, database `kumitedb`, standalone (**not** a replica set, so multi-document transactions are unavailable)
 - Tooling: IntelliJ IDEA, Postman, MongoDB Compass
-- No linter, formatter, or static analysis configured. `mvn test` is the only quality gate.
+- **`mvn verify` is the quality gate** — it runs both test suites. `mvn test` runs only the fast one and does **not** run integration tests.
+- Compiler warnings are enabled (`-Xlint:all,-serial`) in report mode; they do not fail the build yet. No linter, formatter, or static analysis configured (issue #58).
+- Docker must be running for `mvn verify` — integration tests start their own MongoDB via Testcontainers.
 - Frontend: not started
 
 ## Commands
@@ -72,7 +74,10 @@ mvn spring-boot:run
 # Build
 mvn clean install
 
-# Run all tests
+# THE GATE — runs both suites. Requires Docker.
+mvn verify
+
+# Fast suite only (unit + slice). Does NOT run integration tests.
 mvn test
 
 # Run a single test class
@@ -80,11 +85,22 @@ mvn test -Dtest=KumiteGameTimerTest
 
 # Run a single test method
 mvn test -Dtest=KumiteGameTimerTest#testStartGame
+
+# Select a single integration test (the fast suite still runs first)
+mvn verify -Dit.test=ActuatorHealthIT
 ```
+
+**Test suffixes decide which suite a test runs in**, and the mapping is declared explicitly in `pom.xml`:
+
+| Suffix | Suite | Phase | Command |
+|---|---|---|---|
+| `*Test`, `*Tests` | unit and slice | `test` | `mvn test` |
+| `*IT` | integration and end-to-end | `integration-test` | `mvn verify` |
+
+Naming an integration test `*Test` runs it in the fast suite with no container behind it. See `workflow/patterns/testing-strategy.md`.
 
 - Main class: `com.management.kumitegame.KumiteGameStarter` (component scan covers `com.management`)
 - Spring Boot 3.2.3, Java 17 (pinned via `<java.version>` in `pom.xml`)
-- No linter, formatter, or static analysis is configured. `mvn test` is the only quality gate.
 - Windows dev setup: see `karate-app-dev-setup-windows.pdf` in the repo root.
 
 ## MCP Tooling

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,33 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all,-serial</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*Tests.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/workflow/patterns/testing-strategy.md
+++ b/workflow/patterns/testing-strategy.md
@@ -48,6 +48,17 @@ This class of defect is invisible to every assertion in the test. It is only cau
 
 Arrange, act, assert — separated by blank lines, in that order, once. A test with three act phases is three tests.
 
+### The filename suffix selects the suite
+
+Build tools route a test file into a suite by its filename. That makes the suffix a functional decision rather than a stylistic one: renaming a file moves it between suites, and an integration test that lands in the fast suite runs with no infrastructure behind it — where it either fails confusingly or passes for the wrong reason.
+
+Bind one suffix per suite, and declare the mapping explicitly in the build rather than inheriting the tool's defaults. Defaults are typically wider than intended and often match on prefix as well, which drags helper classes into the run as though they were tests.
+
+- **Fast suite** — unit and slice tests. Runs on every build, needs nothing external.
+- **Slow suite** — integration and end-to-end tests. Gated behind real infrastructure.
+
+Keeping the suites separate is what keeps the fast one fast. But **one documented command must run both.** A gate that passes locally while the pipeline runs strictly more than it is not a gate; it is a rehearsal, and the difference surfaces as a pipeline failure nobody can reproduce.
+
 ## Fixtures
 
 Build test data with named builders exposing intent-revealing defaults, so each test states only the field it cares about. A test that sets eleven fields to reach one assertion hides which field matters.
@@ -63,6 +74,7 @@ Before optimising anything else, count how many distinct contexts the suite buil
 ## Verify
 
 - Suite passes from a clean checkout with no ordering dependence, and passes when run in reverse order.
+- The single documented command runs every suite. No test is reachable only by a command the team does not run.
 - Reverting any recent fix turns exactly one test red.
 - Removing a persisted field's storage makes at least one test fail.
 - Context build count is known and justified.


### PR DESCRIPTION
Closes #83. First issue in Epic #82.

## The problem

`maven-failsafe-plugin` is bound to `integration-test` and `verify`, but surefire's default includes
(`Test*.java`, `*Test.java`, `*Tests.java`, `*TestCase.java`) do not match `ActuatorHealthIT`. So
`mvn test` — the command `CLAUDE.md` named as the only quality gate — ran 5 of the 7 tests and
reported green.

CI was never affected; it runs `mvn verify`. The gap was local and documentary, which is the worse
kind: a developer could pass the documented gate and still be surprised by CI.

## Changes

**`pom.xml`**
- Surefire pinned to `**/*Test.java` and `**/*Tests.java`; failsafe to `**/*IT.java`. Deliberately
  narrower than the surefire default, which also matches `Test*.java` — that would pick up a helper
  class named `TestSomething` and try to run it. #85 adds fixture builders, so this trap was about
  to be live.
- Compiler warnings enabled via `-Xlint:all,-serial`, in report mode with no `-Werror`.

**`workflow/patterns/testing-strategy.md`** — the suffix convention, under *Naming and shape*.
Written with no tool, plugin, project or issue references, per the `workflow/` transferability rule.

**`CLAUDE.md`** — both "`mvn test` is the only quality gate" claims corrected, `mvn verify` named as
the gate, a suffix→suite→command table added, and the Docker prerequisite stated.

**`.github/workflows/ci.yml`** — failsafe reports uploaded alongside surefire; artifact renamed to
`test-reports`.

## On the compiler warnings

`-Xlint:all` reported exactly four warnings, all `serial`: missing `serialVersionUID` on the four
classes in `com.management.exceptions`. They are plain `RuntimeException`s thrown within a single JVM
and never serialized.

`serial` is excluded rather than satisfied. Adding four meaningless constants buys nothing, and four
permanently-ignored warnings are how a team learns to ignore the gate. `enforcement.md` treats a
suppression as a decision that carries a reason — this is the reason. The remaining baseline is zero,
and the ratchet belongs to #58.

## On the Testcontainers override

`<testcontainers.version>1.21.4</testcontainers.version>` overrides the 1.19.5 that Boot 3.2.3
manages. It stays, and it is load-bearing rather than drift.

Verified empirically on Docker Engine 29.4.3:

| Version | Result |
|---|---|
| 1.21.4 (pinned) | negotiates Docker API 1.54, suite passes |
| 1.19.5 (Boot-managed, forced via `-D`) | `Could not find a valid Docker environment`, HTTP 400, build fails |

Docker Engine 29 raised its minimum API version above what the Docker client bundled with
Testcontainers 1.19.x speaks. Remove the override and the integration suite stops running.

It should be **deleted, not bumped**, when Epic #89 lands — Boot 4.x manages Testcontainers 2.x and
needs no override.

## Verification

| Check | Result |
|---|---|
| `mvn clean verify` | BUILD SUCCESS — surefire 5, failsafe 2 |
| `mvn test` | 5 tests; integration test correctly not run |
| `mvn verify -Dit.test=ActuatorHealthIT` | selects the IT as documented |
| Compiler warnings | 0 |
| `project.build.sourceEncoding` | `UTF-8`, supplied by the Boot parent — verified, not re-declared |
| `<parameters>true</parameters>` | confirmed present in the effective POM |

The last two are the other *Required build settings* in `workflow/standards/enforcement.md`; both
were already satisfied by the parent, so nothing was added for them.

## One thing to check before merging

This branch also removes a pre-existing comment block above `permissions:` in `ci.yml` that warned
against switching the workflow to `pull_request_target`. That comment predates this work and is not
related to the test gate. If its removal was not intended, say so and it goes back in a one-line
commit.

## Not in scope

No production code changed. Coverage measurement is #84; the formatter and analysers are #58;
`KumiteGameControllerTests` is deleted in #87.
