### PR TITLE
build: add formatter, static analysers and quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege. `pull_request` already runs fork code without repository
+# secrets and with a read-only token; this pins it explicitly.
+# Never switch this workflow to `pull_request_target` -- that trigger grants
+# secrets to code from forks. This is not hypothetical: the usual workaround
+# for "my code-analysis service can't see fork PRs" is exactly that switch,
+# and it is the reason SonarQube Cloud was rejected for this repo rather than
+# worked around. Most PRs here come from forks.
 permissions:
   contents: read
 
+# A new push to a branch cancels the run still in flight for it.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,26 +98,34 @@ mvn verify -Dit.test=ActuatorHealthIT
 
 Naming an integration test `*Test` runs it in the fast suite with no container behind it. See `workflow/patterns/testing-strategy.md`.
 
-### Quality gates
+### Quality gates — the tool registry
 
-All run inside `mvn verify`. Gate order follows `workflow/standards/enforcement.md`.
+Three engines, three non-overlapping jobs. All run inside `mvn verify`; gate order follows `workflow/standards/enforcement.md`. **No two tools have authority over the same category** — if a finding is reported twice, that is a bug in this setup, not thoroughness.
 
-| Gate | Tool | Mode | Baseline |
-|---|---|---|---|
-| Formatter | Spotless + google-java-format | **enforced** — build fails on unformatted code | 0 |
-| Style (published) | Checkstyle, `google_checks.xml` | ratchet | **131** |
-| Style (project rules) | Checkstyle, `config/checkstyle/project-standards.xml` | ratchet | **4** |
-| Correctness | Error Prone + NullAway | report only | **35** (19 NullAway) |
-| Compiler | `-Xlint:all,-serial` | report only | 0 |
+| Tool | Owns | Configured in | Mode | Baseline |
+|---|---|---|---|---|
+| **Spotless** + google-java-format | **Layout** — indentation, wrapping, import order, whitespace | `pom.xml` → `spotless-maven-plugin` | **Enforced.** Build fails; `mvn spotless:apply` fixes | 0 |
+| **Checkstyle** (published) | **Conventions** — naming, structure, braces, star imports | `config/checkstyle/google-checks-vendored.xml` | Ratchet | **21** |
+| **Checkstyle** (project) | **`java.md`'s own rules** — logger naming, `printStackTrace`, `Optional` misuse | `config/checkstyle/project-standards.xml` | Ratchet | **4** |
+| **Error Prone + NullAway** | **Correctness** — null analysis, API misuse, time/locale bugs | `pom.xml` → `maven-compiler-plugin` `compilerArgs` + `annotationProcessorPaths` | Report only | **34** (19 NullAway) |
+| **javac** | Compiler warnings | `pom.xml` → `-Xlint:all,-serial` | Report only | 0 |
 
 ```bash
-# Reformat everything. Run this before committing if the build fails on formatting.
-mvn spotless:apply
+mvn spotless:apply    # fix formatting — run this if the build fails on layout
+mvn verify            # everything
 ```
 
-**The ratchet:** Checkstyle's `maxAllowedViolations` is set to the baseline, so the build fails if the count *rises*. Lower the number in `pom.xml` as findings are fixed — it never goes up. Error Prone has no count ratchet in javac, so it stays report-only until the 35 are cleared and NullAway can be switched to `ERROR`.
+**How to change each one**
 
-Suppressions live in `config/checkstyle/suppressions.xml`, one reason per entry.
+- **Formatting rules** — not configurable by design. google-java-format has no options; that is why it was chosen.
+- **Published conventions** — edit the vendored ruleset. Its header explains what was removed from the upstream `google_checks.xml` and why, and how to re-vendor after a Checkstyle upgrade.
+- **Project rules** — edit `project-standards.xml`. Every module there cites the `java.md` rule it mechanises. New rule in `java.md` → new module here.
+- **Correctness** — Error Prone checks are toggled with `-Xep:CheckName:OFF|WARN|ERROR` in the compiler args.
+- **Suppressions** — `config/checkstyle/suppressions.xml`, one entry per reason. A suppression with no reason gets rejected in review.
+
+**The ratchet.** `maxAllowedViolations` is set to the current baseline, so the build fails if the count *rises*. Lower it as findings are fixed; it never goes up. Error Prone has no count ratchet in javac, so it stays report-only until the 34 are cleared and NullAway can move to `ERROR`.
+
+**Deliberately not used: SonarQube.** It would duplicate most of the above — SonarSource has itself deprecated 158 Checkstyle/PMD rules as redundant with SonarJava. More decisively, its value here would be the PR gate, and GitHub withholds secrets from `pull_request` runs originating in forks. Most PRs on this repo come from forks, so Sonar would silently skip them. The usual workaround is `pull_request_target`, which hands secrets to fork-authored code — see the warning in `.github/workflows/ci.yml`. Revisit only if contribution stops coming through forks.
 
 - Main class: `com.management.kumitegame.KumiteGameStarter` (component scan covers `com.management`)
 - Spring Boot 3.2.3, Java 17 (pinned via `<java.version>` in `pom.xml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ All run inside `mvn verify`. Gate order follows `workflow/standards/enforcement.
 |---|---|---|---|
 | Formatter | Spotless + google-java-format | **enforced** — build fails on unformatted code | 0 |
 | Style (published) | Checkstyle, `google_checks.xml` | ratchet | **131** |
-| Style (project rules) | Checkstyle, `config/checkstyle/project-standards.xml` | ratchet | **18** |
+| Style (project rules) | Checkstyle, `config/checkstyle/project-standards.xml` | ratchet | **4** |
 | Correctness | Error Prone + NullAway | report only | **35** (19 NullAway) |
 | Compiler | `-Xlint:all,-serial` | report only | 0 |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,7 @@ No transition guard is currently enforced — every transition is permitted by t
 - Spring Boot 3.2.3, Maven, embedded Tomcat
 - MongoDB 7 in Docker — `localhost:27017`, database `kumitedb`, standalone (**not** a replica set, so multi-document transactions are unavailable)
 - Tooling: IntelliJ IDEA, Postman, MongoDB Compass
-- **`mvn verify` is the quality gate** — it runs both test suites. `mvn test` runs only the fast one and does **not** run integration tests.
-- Compiler warnings are enabled (`-Xlint:all,-serial`) in report mode; they do not fail the build yet. No linter, formatter, or static analysis configured (issue #58).
+- **`mvn verify` is the quality gate** — it runs every check below plus both test suites. `mvn test` runs only the fast suite and does **not** run integration tests.
 - Docker must be running for `mvn verify` — integration tests start their own MongoDB via Testcontainers.
 - Frontend: not started
 
@@ -98,6 +97,27 @@ mvn verify -Dit.test=ActuatorHealthIT
 | `*IT` | integration and end-to-end | `integration-test` | `mvn verify` |
 
 Naming an integration test `*Test` runs it in the fast suite with no container behind it. See `workflow/patterns/testing-strategy.md`.
+
+### Quality gates
+
+All run inside `mvn verify`. Gate order follows `workflow/standards/enforcement.md`.
+
+| Gate | Tool | Mode | Baseline |
+|---|---|---|---|
+| Formatter | Spotless + google-java-format | **enforced** — build fails on unformatted code | 0 |
+| Style (published) | Checkstyle, `google_checks.xml` | ratchet | **131** |
+| Style (project rules) | Checkstyle, `config/checkstyle/project-standards.xml` | ratchet | **18** |
+| Correctness | Error Prone + NullAway | report only | **35** (19 NullAway) |
+| Compiler | `-Xlint:all,-serial` | report only | 0 |
+
+```bash
+# Reformat everything. Run this before committing if the build fails on formatting.
+mvn spotless:apply
+```
+
+**The ratchet:** Checkstyle's `maxAllowedViolations` is set to the baseline, so the build fails if the count *rises*. Lower the number in `pom.xml` as findings are fixed — it never goes up. Error Prone has no count ratchet in javac, so it stays report-only until the 35 are cleared and NullAway can be switched to `ERROR`.
+
+Suppressions live in `config/checkstyle/suppressions.xml`, one reason per entry.
 
 - Main class: `com.management.kumitegame.KumiteGameStarter` (component scan covers `com.management`)
 - Spring Boot 3.2.3, Java 17 (pinned via `<java.version>` in `pom.xml`)

--- a/config/checkstyle/google-checks-vendored.xml
+++ b/config/checkstyle/google-checks-vendored.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Mauryan Kansara, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<!--
+    VENDORED COPY. Source: google_checks.xml, bundled in checkstyle 10.26.1.
+
+    Vendored rather than referenced by name for two reasons:
+
+    1. The bundled ruleset ships inside the Checkstyle jar, so bumping checkstyle.version can
+       change which rules run and therefore the violation count. That would move the ratchet
+       baseline for a reason that has nothing to do with the code. Vendoring pins it, and a
+       ruleset change becomes a reviewable diff.
+    2. Two categories of rule are deliberately removed. A deviation belongs in the ruleset where
+       it is visible in one place, not in a blanket suppression. See
+       workflow/standards/enforcement.md.
+
+    REMOVED - layout (28 modules). google-java-format, applied by Spotless, is the sole authority
+    on layout. These rules re-check what the formatter has already guaranteed: FileTabCharacter,
+    LineLength, NoLineWrap, LeftCurly, RightCurly, WhitespaceAfter, WhitespaceAround,
+    EmptyLineSeparator, SeparatorWrap, GenericWhitespace, Indentation, MethodParamPad,
+    NoWhitespaceBefore, NoWhitespaceBeforeCaseDefaultColon, ParenPad, OperatorWrap,
+    AnnotationLocation, CommentsIndentation, CustomImportOrder,
+    JavadocTagContinuationIndentation, and the empty-block-spacing RegexpSinglelineJava.
+
+    Kept deliberately despite looking layout-adjacent: AvoidStarImport and NeedBraces. Neither
+    google-java-format nor Spotless expands star imports or adds missing braces.
+
+    REMOVED - MissingJavadocMethod, MissingJavadocType. Javadoc is not required on every public
+    member of this codebase. Javadoc *quality* checks are kept, so anything written must be
+    well-formed: SummaryJavadoc, JavadocParagraph, NonEmptyAtclauseDescription,
+    RequireEmptyLineBeforeBlockTagGroup, AtclauseOrder, JavadocMethod, SingleLineJavadoc,
+    InvalidJavadocPosition.
+
+    To re-vendor after a Checkstyle upgrade: extract google_checks.xml from the new jar, reapply
+    the two removals above, and re-baseline maxAllowedViolations in pom.xml.
+ -->
+
+<module name="Checker">
+
+  <property name="charset" value="UTF-8" />
+
+  <property name="severity" value="${org.checkstyle.google.severity}" default="warning" />
+
+  <property name="fileExtensions" value="java, properties, xml" />
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$" />
+  </module>
+
+  <module name="SuppressWarningsFilter" />
+
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}" default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true" />
+  </module>
+
+  <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern" value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines" />
+    <property name="checkPattern" value="$1" />
+    <property name="lineRange" value="$2" />
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename" />
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL" />
+      <property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)" />
+      <property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value." />
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true" />
+      <property name="allowByTailComment" value="true" />
+      <property name="allowNonPrintableEscapes" value="true" />
+    </module>
+    <module name="AvoidStarImport" />
+    <module name="OneTopLevelClass" />
+    <module name="NeedBraces">
+      <property name="tokens" value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE" />
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
+      <property name="id" value="LeftCurlyNl" />
+      <property name="query" value="//SWITCH_RULE/SLIST" />
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="id" value="RightCurlySame" />
+      <property name="query" value="//RCURLY[parent::SLIST[parent::LITERAL_CATCH&#xA;                               and not(parent::LITERAL_CATCH/following-sibling::*)]]" />
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppression is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone" />
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1&#xA;                               and not(parent::LITERAL_CATCH)]&#xA;                               or (preceding-sibling::*[last()][self::LCURLY]&#xA;                               and not(parent::SLIST/parent::LITERAL_CATCH))&#xA;                               or (parent::SLIST/parent::LITERAL_CATCH&#xA;                               and parent::SLIST/parent::LITERAL_CATCH/following-sibling::*)]" />
+    </module>
+    <module name="OneStatementPerLine" />
+    <module name="MultipleVariableDeclarations" />
+    <module name="ArrayTypeStyle" />
+    <module name="MissingSwitchDefault" />
+    <module name="FallThrough" />
+    <module name="UpperEll" />
+    <module name="ModifierOrder" />
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$" />
+      <message key="name.invalidPattern" value="Package name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,&#xA;                    ANNOTATION_DEF, RECORD_DEF" />
+      <message key="name.invalidPattern" value="Type name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+      <message key="name.invalidPattern" value="Member name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+      <message key="name.invalidPattern" value="Parameter name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+      <message key="name.invalidPattern" value="Lambda parameter name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+      <message key="name.invalidPattern" value="Catch parameter name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+      <message key="name.invalidPattern" value="Local variable name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+      <message key="name.invalidPattern" value="Pattern variable name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <message key="name.invalidPattern" value="Class type name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+      <message key="name.invalidPattern" value="Record component name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <message key="name.invalidPattern" value="Record type name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <message key="name.invalidPattern" value="Method type name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <message key="name.invalidPattern" value="Interface type name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="NoFinalizer" />
+
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false" />
+      <property name="allowedAbbreviationLength" value="0" />
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,&#xA;                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,&#xA;                    RECORD_COMPONENT_DEF" />
+    </module>
+    <module name="OverloadMethodsDeclarationOrder" />
+    <module name="ConstructorsDeclarationGrouping" />
+    <module name="VariableDeclarationUsageDistance" />
+    <module name="NonEmptyAtclauseDescription" />
+    <module name="InvalidJavadocPosition" />
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )" />
+    </module>
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false" />
+    </module>
+    <module name="RequireEmptyLineBeforeBlockTagGroup" />
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated" />
+      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF" />
+    </module>
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public" />
+      <property name="allowMissingParamTags" value="true" />
+      <property name="allowMissingReturnTag" value="true" />
+      <property name="allowedAnnotations" value="Override, Test" />
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF" />
+    </module>
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$" />
+      <message key="name.invalidPattern" value="Method name ''{0}'' must match pattern ''{1}''." />
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MethodName" />
+      <property name="query" value="//METHOD_DEF[&#xA;                                     ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]&#xA;                                   ]/IDENT" />
+      <property name="message" value="'[a-z][a-z0-9][a-zA-Z0-9]*(?:_[a-z][a-z0-9][a-zA-Z0-9]*)*'" />
+    </module>
+    <module name="SingleLineJavadoc" />
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected" />
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}" default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true" />
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)" />
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1" />
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1" />
+    </module>
+  </module>
+</module>

--- a/config/checkstyle/project-standards.xml
+++ b/config/checkstyle/project-standards.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+  Mechanises the rules already written in workflow/standards/java.md.
+
+  This is NOT a general-purpose ruleset. google_checks.xml is the published ruleset and runs as a
+  separate execution; this file exists only to enforce the project's own written standards, which
+  no published ruleset knows about. Every module below cites the java.md rule it implements.
+
+  Layout, whitespace and line length are deliberately absent: Spotless owns formatting. A rule here
+  that disagrees with google-java-format would be unfixable.
+-->
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+  <property name="severity" value="warning"/>
+  <property name="fileExtensions" value="java"/>
+
+  <module name="SuppressionFilter">
+    <property name="file" value="${checkstyle.suppressions.file}"/>
+    <property name="optional" value="false"/>
+  </module>
+
+  <module name="TreeWalker">
+
+    <!-- java.md: "Never call printStackTrace()." Found once in the audit already. -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="ForbidPrintStackTrace"/>
+      <property name="format" value="\.printStackTrace\s*\("/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message"
+                value="java.md: never call printStackTrace() - it bypasses the log pipeline. Log with the throwable as the final argument."/>
+    </module>
+
+    <!-- java.md naming table: logger field is `private static final Logger log`. -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="LoggerFieldName"/>
+      <property name="format" value="\bLogger\s+(?!log\b)\w+\s*="/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="java.md: the logger field must be named 'log'."/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="LoggerFieldVisibility"/>
+      <property name="format" value="^\s*(public|protected)\s+.*\bLogger\s+\w+\s*="/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="java.md: the logger field must be private static final."/>
+    </module>
+
+    <!-- java.md: "Optional is a return type, never a field or a parameter." -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="OptionalAsParameter"/>
+      <property name="format" value="[(,]\s*(final\s+)?Optional&lt;"/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="java.md: Optional is a return type, never a parameter."/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="OptionalAsField"/>
+      <property name="format" value="^\s*(private|protected|public)\s+(static\s+|final\s+)*Optional&lt;"/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="java.md: Optional is a return type, never a field."/>
+    </module>
+
+    <!-- java.md naming table: boolean accessors are isX / hasX. -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="BooleanAccessorName"/>
+      <property name="format"
+                value="public\s+boolean\s+(?!is[A-Z]|has[A-Z]|equals\s*\()\w+\s*\("/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="java.md: a boolean accessor is named isX or hasX."/>
+    </module>
+
+    <!--
+      java.md naming table: constants are UPPER_SNAKE, private static final.
+
+      'log' is permitted explicitly. The same table mandates `private static final Logger log`, and
+      a logger is a static final field, so the default UPPER_SNAKE format would make the two rules
+      contradict: satisfying the logger rule would permanently violate this one. java.md is
+      authoritative, so the ruleset accommodates it rather than the reverse.
+    -->
+    <module name="ConstantName">
+      <property name="format" value="^(log|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)$"/>
+    </module>
+
+    <!-- java.md: "equals, hashCode, toString on every type placed in a collection or logged." -->
+    <module name="EqualsHashCode"/>
+
+    <!-- java.md: "Static utility classes get a private throwing constructor, and hold no state." -->
+    <module name="HideUtilityClassConstructor"/>
+
+    <!-- java.md verify: "no new public mutable static". -->
+    <module name="VisibilityModifier">
+      <property name="protectedAllowed" value="false"/>
+      <property name="allowPublicFinalFields" value="true"/>
+      <property name="allowPublicImmutableFields" value="true"/>
+    </module>
+
+  </module>
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<!--
+  Every suppression is a decision and carries a reason, per workflow/standards/enforcement.md:
+
+    "A suppression is a decision, so it carries a reason. Blanket file-level or project-level
+     suppression of a rule is equivalent to deleting the rule."
+
+  Suppress the narrowest thing that works, and say why. An entry with no reason is not reviewable
+  and should be rejected.
+-->
+<suppressions>
+
+  <!--
+    VisibilityModifier fires on every @Autowired / @Value field. Field injection is a real finding
+    and is tracked as issue #43 (convert field injection to constructor injection), which will
+    delete these fields rather than change their visibility. Suppressing here would hide #43's own
+    evidence, so this is scoped to nothing today and left as the documented place to add a scope if
+    the noise blocks work.
+
+    Deliberately empty. Do not add a blanket suppression for it.
+  -->
+
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
               <violationSeverity>warning</violationSeverity>
               <logViolationsToConsole>true</logViolationsToConsole>
               <failOnViolation>true</failOnViolation>
-              <maxAllowedViolations>18</maxAllowedViolations>
+              <maxAllowedViolations>4</maxAllowedViolations>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,14 @@
             <arg>-XDcompilePolicy=simple</arg>
             <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
             <arg>--should-stop=ifError=FLOW</arg>
+            <!--
+              CatchAndPrintStackTrace is OFF because config/checkstyle/project-standards.xml
+              already enforces this as ForbidPrintStackTrace. One defect, one source: the
+              Checkstyle rule is kept because it catches every printStackTrace call rather than
+              only those inside a catch block, and its message cites the java.md rule.
+            -->
             <arg>-Xplugin:ErrorProne -XepAllErrorsAsWarnings -XepAllSuggestionsAsWarnings
+              -Xep:CatchAndPrintStackTrace:OFF
               -Xep:NullAway:WARN -XepOpt:NullAway:AnnotatedPackages=com.management</arg>
           </compilerArgs>
           <annotationProcessorPaths>
@@ -152,12 +159,12 @@
               <goal>check</goal>
             </goals>
             <configuration>
-              <configLocation>google_checks.xml</configLocation>
+              <configLocation>config/checkstyle/google-checks-vendored.xml</configLocation>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <violationSeverity>warning</violationSeverity>
               <logViolationsToConsole>true</logViolationsToConsole>
               <failOnViolation>true</failOnViolation>
-              <maxAllowedViolations>131</maxAllowedViolations>
+              <maxAllowedViolations>21</maxAllowedViolations>
             </configuration>
           </execution>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
   <properties>
     <java.version>17</java.version>
     <testcontainers.version>1.21.4</testcontainers.version>
+    <spotless.version>2.44.5</spotless.version>
+    <google-java-format.version>1.27.0</google-java-format.version>
+    <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+    <checkstyle.version>10.26.1</checkstyle.version>
+    <error-prone.version>2.39.0</error-prone.version>
+    <nullaway.version>0.12.7</nullaway.version>
   </properties>
 
   <dependencies>
@@ -83,8 +89,94 @@
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all,-serial</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne -XepAllErrorsAsWarnings -XepAllSuggestionsAsWarnings
+              -Xep:NullAway:WARN -XepOpt:NullAway:AnnotatedPackages=com.management</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+            <path>
+              <groupId>com.uber.nullaway</groupId>
+              <artifactId>nullaway</artifactId>
+              <version>${nullaway.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>${google-java-format.version}</version>
+            </googleJavaFormat>
+            <removeUnusedImports/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>checkstyle-google</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <configLocation>google_checks.xml</configLocation>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <violationSeverity>warning</violationSeverity>
+              <logViolationsToConsole>true</logViolationsToConsole>
+              <failOnViolation>true</failOnViolation>
+              <maxAllowedViolations>131</maxAllowedViolations>
+            </configuration>
+          </execution>
+          <execution>
+            <id>checkstyle-project-standards</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <configLocation>config/checkstyle/project-standards.xml</configLocation>
+              <suppressionsLocation>config/checkstyle/suppressions.xml</suppressionsLocation>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <violationSeverity>warning</violationSeverity>
+              <logViolationsToConsole>true</logViolationsToConsole>
+              <failOnViolation>true</failOnViolation>
+              <maxAllowedViolations>18</maxAllowedViolations>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/src/main/java/com/management/controllers/KumiteGameController.java
+++ b/src/main/java/com/management/controllers/KumiteGameController.java
@@ -13,66 +13,56 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/kumitegame")
 public class KumiteGameController {
 
-    @Autowired
-    private KumiteGameService kumiteGameService;
+  @Autowired private KumiteGameService kumiteGameService;
 
-    @Autowired
-    private PlayerService playerService;
+  @Autowired private PlayerService playerService;
 
-    @PostMapping
-    public ResponseEntity<KumiteGame> createKumiteGame(@RequestBody KumiteGameRequestDTO gameDetails) {
-        KumiteGame createdGame = kumiteGameService.createKumiteGame(gameDetails);
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .header("Location", "/api/kumitegame/" + createdGame.getId())
-                .body(createdGame);
-    }
+  @PostMapping
+  public ResponseEntity<KumiteGame> createKumiteGame(
+      @RequestBody KumiteGameRequestDTO gameDetails) {
+    KumiteGame createdGame = kumiteGameService.createKumiteGame(gameDetails);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .header("Location", "/api/kumitegame/" + createdGame.getId())
+        .body(createdGame);
+  }
 
-    @GetMapping("/{gameId}")
-    public ResponseEntity<KumiteGame> getKumiteGame(@PathVariable String gameId) {
-        KumiteGame kumiteGame = kumiteGameService.getKumiteGame(gameId);
-        return ResponseEntity.ok(kumiteGame);
-    }
+  @GetMapping("/{gameId}")
+  public ResponseEntity<KumiteGame> getKumiteGame(@PathVariable String gameId) {
+    KumiteGame kumiteGame = kumiteGameService.getKumiteGame(gameId);
+    return ResponseEntity.ok(kumiteGame);
+  }
 
-    @PutMapping("/{gameId}/add-point")
-    public ResponseEntity<String> addPoint(
-            @PathVariable String gameId,
-            @RequestParam String color,
-            @RequestParam String pointType) {
-            playerService.addPoint(gameId, color, pointType);
-            return ResponseEntity.ok("Point added successfully.");
-    }
+  @PutMapping("/{gameId}/add-point")
+  public ResponseEntity<String> addPoint(
+      @PathVariable String gameId, @RequestParam String color, @RequestParam String pointType) {
+    playerService.addPoint(gameId, color, pointType);
+    return ResponseEntity.ok("Point added successfully.");
+  }
 
-    @PutMapping("/{gameId}/remove-point")
-    public ResponseEntity<String> removePoint(
-            @PathVariable String gameId,
-            @RequestParam String color,
-            @RequestParam String pointType) {
-        playerService.removePoint(gameId, color, pointType);
-        return ResponseEntity.ok("Point removed successfully.");
-    }
+  @PutMapping("/{gameId}/remove-point")
+  public ResponseEntity<String> removePoint(
+      @PathVariable String gameId, @RequestParam String color, @RequestParam String pointType) {
+    playerService.removePoint(gameId, color, pointType);
+    return ResponseEntity.ok("Point removed successfully.");
+  }
 
-    @PutMapping("/{gameId}/add-foul")
-    public ResponseEntity<String> addFoul(
-            @PathVariable String gameId,
-            @RequestParam String color) {
-        playerService.addFoul(gameId, color);
-        return ResponseEntity.ok("Foul added successfully.");
-    }
+  @PutMapping("/{gameId}/add-foul")
+  public ResponseEntity<String> addFoul(@PathVariable String gameId, @RequestParam String color) {
+    playerService.addFoul(gameId, color);
+    return ResponseEntity.ok("Foul added successfully.");
+  }
 
-    @PutMapping("/{gameId}/remove-foul")
-    public ResponseEntity<String> removeFoul(
-            @PathVariable String gameId,
-            @RequestParam String color) {
-        playerService.removeFoul(gameId, color);
-        return ResponseEntity.ok("Foul removed successfully.");
-    }
+  @PutMapping("/{gameId}/remove-foul")
+  public ResponseEntity<String> removeFoul(
+      @PathVariable String gameId, @RequestParam String color) {
+    playerService.removeFoul(gameId, color);
+    return ResponseEntity.ok("Foul removed successfully.");
+  }
 
-    @PutMapping("/{gameId}/update-winner/{color}")
-    public ResponseEntity<KumiteGame> updateKumiteGameWinner(
-            @PathVariable String gameId,
-            @PathVariable String color) {
-        KumiteGame updatedGame = kumiteGameService.updateKumiteGameWinner(gameId, color);
-        return ResponseEntity.ok(updatedGame);
-    }
+  @PutMapping("/{gameId}/update-winner/{color}")
+  public ResponseEntity<KumiteGame> updateKumiteGameWinner(
+      @PathVariable String gameId, @PathVariable String color) {
+    KumiteGame updatedGame = kumiteGameService.updateKumiteGameWinner(gameId, color);
+    return ResponseEntity.ok(updatedGame);
+  }
 }

--- a/src/main/java/com/management/controllers/PlayerController.java
+++ b/src/main/java/com/management/controllers/PlayerController.java
@@ -13,34 +13,31 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/players")
 public class PlayerController {
 
-    @Autowired
-    private PlayerService playerService;
+  @Autowired private PlayerService playerService;
 
-    @PostMapping
-    public ResponseEntity<PlayerResponseDTO> createPlayer(@RequestBody PlayerRequestDTO newPlayer) {
-        Player savedPlayer = playerService.createPlayer(newPlayer);
-        PlayerResponseDTO response = new PlayerResponseDTO (
-                savedPlayer.getId(),
-                savedPlayer.getName(),
-                savedPlayer.getPoints().getNumOfPoints(),
-                savedPlayer.getFouls().getNumOfFouls()
-        );
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .header("Location", "/api/players/" + savedPlayer.getId())
-                .body(response);
-    }
+  @PostMapping
+  public ResponseEntity<PlayerResponseDTO> createPlayer(@RequestBody PlayerRequestDTO newPlayer) {
+    Player savedPlayer = playerService.createPlayer(newPlayer);
+    PlayerResponseDTO response =
+        new PlayerResponseDTO(
+            savedPlayer.getId(),
+            savedPlayer.getName(),
+            savedPlayer.getPoints().getNumOfPoints(),
+            savedPlayer.getFouls().getNumOfFouls());
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .header("Location", "/api/players/" + savedPlayer.getId())
+        .body(response);
+  }
 
-    @GetMapping("/{playerId}")
-    public ResponseEntity<Player> getPlayer(@PathVariable String playerId) {
-        Player player = playerService.getPlayer(playerId);
-        return ResponseEntity.ok(player);
-    }
+  @GetMapping("/{playerId}")
+  public ResponseEntity<Player> getPlayer(@PathVariable String playerId) {
+    Player player = playerService.getPlayer(playerId);
+    return ResponseEntity.ok(player);
+  }
 
-    @DeleteMapping("/{playerId}")
-    public ResponseEntity<String> deletePlayer(@PathVariable String playerId) {
-        playerService.deletePlayer(playerId);
-        return ResponseEntity.ok("Player deleted successfully.");
-    }
-
+  @DeleteMapping("/{playerId}")
+  public ResponseEntity<String> deletePlayer(@PathVariable String playerId) {
+    playerService.deletePlayer(playerId);
+    return ResponseEntity.ok("Player deleted successfully.");
+  }
 }

--- a/src/main/java/com/management/dto/KumiteGameRequestDTO.java
+++ b/src/main/java/com/management/dto/KumiteGameRequestDTO.java
@@ -4,32 +4,32 @@ import java.util.List;
 import java.util.Map;
 
 public class KumiteGameRequestDTO {
-    private Map<String, PlayerDTO> playersMap;
-    private List<String> refereeList;
+  private Map<String, PlayerDTO> playersMap;
+  private List<String> refereeList;
 
-    private String gameDuration;
+  private String gameDuration;
 
-    public Map<String, PlayerDTO> getPlayersMap() {
-        return playersMap;
-    }
+  public Map<String, PlayerDTO> getPlayersMap() {
+    return playersMap;
+  }
 
-    public void setPlayersMap(Map<String, PlayerDTO> playersMap) {
-        this.playersMap = playersMap;
-    }
+  public void setPlayersMap(Map<String, PlayerDTO> playersMap) {
+    this.playersMap = playersMap;
+  }
 
-    public List<String> getRefereeList() {
-        return refereeList;
-    }
+  public List<String> getRefereeList() {
+    return refereeList;
+  }
 
-    public void setRefereeList(List<String> refereeList) {
-        this.refereeList = refereeList;
-    }
+  public void setRefereeList(List<String> refereeList) {
+    this.refereeList = refereeList;
+  }
 
-    public String getGameDuration() {
-        return gameDuration;
-    }
+  public String getGameDuration() {
+    return gameDuration;
+  }
 
-    public void setGameDuration(String gameDuration) {
-        this.gameDuration = gameDuration;
-    }
+  public void setGameDuration(String gameDuration) {
+    this.gameDuration = gameDuration;
+  }
 }

--- a/src/main/java/com/management/dto/KumiteGameResponseDTO.java
+++ b/src/main/java/com/management/dto/KumiteGameResponseDTO.java
@@ -4,43 +4,44 @@ import java.util.List;
 
 public class KumiteGameResponseDTO {
 
-    private String gameId;
-    private String player1;
-    private String player2;
-    private List<String> referees;
+  private String gameId;
+  private String player1;
+  private String player2;
+  private List<String> referees;
 
-    public KumiteGameResponseDTO(String gameId, String player1, String player2, List<String> referees) {
-        this.gameId = gameId;
-        this.player1 = player1;
-        this.player2 = player2;
-        this.referees = referees;
-    }
+  public KumiteGameResponseDTO(
+      String gameId, String player1, String player2, List<String> referees) {
+    this.gameId = gameId;
+    this.player1 = player1;
+    this.player2 = player2;
+    this.referees = referees;
+  }
 
-    public String getGameId() {
-        return gameId;
-    }
+  public String getGameId() {
+    return gameId;
+  }
 
-    public String getPlayer1() {
-        return player1;
-    }
+  public String getPlayer1() {
+    return player1;
+  }
 
-    public void setPlayer1(String player1) {
-        this.player1 = player1;
-    }
+  public void setPlayer1(String player1) {
+    this.player1 = player1;
+  }
 
-    public String getPlayer2() {
-        return player2;
-    }
+  public String getPlayer2() {
+    return player2;
+  }
 
-    public void setPlayer2(String player2) {
-        this.player2 = player2;
-    }
+  public void setPlayer2(String player2) {
+    this.player2 = player2;
+  }
 
-    public List<String> getReferees() {
-        return referees;
-    }
+  public List<String> getReferees() {
+    return referees;
+  }
 
-    public void setReferees(List<String> referees) {
-        this.referees = referees;
-    }
+  public void setReferees(List<String> referees) {
+    this.referees = referees;
+  }
 }

--- a/src/main/java/com/management/dto/PlayerDTO.java
+++ b/src/main/java/com/management/dto/PlayerDTO.java
@@ -1,37 +1,38 @@
 package com.management.dto;
 
 public class PlayerDTO {
-    private String id;
-    private String name;
-    private String color;
+  private String id;
+  private String name;
+  private String color;
 
-    public PlayerDTO(){}
-    public PlayerDTO(String name, String color){
-        this.name = name;
-        this.color = color;
-    }
+  public PlayerDTO() {}
 
-    public String getId() {
-        return id;
-    }
+  public PlayerDTO(String name, String color) {
+    this.name = name;
+    this.color = color;
+  }
 
-    public void setId(String id) {
-        this.id = id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public String getColor() {
-        return color;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public void setColor(String color) {
-        this.color = color;
-    }
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
 }

--- a/src/main/java/com/management/dto/PlayerRequestDTO.java
+++ b/src/main/java/com/management/dto/PlayerRequestDTO.java
@@ -1,13 +1,13 @@
 package com.management.dto;
 
 public class PlayerRequestDTO {
-    private String name;
+  private String name;
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 }

--- a/src/main/java/com/management/dto/PlayerResponseDTO.java
+++ b/src/main/java/com/management/dto/PlayerResponseDTO.java
@@ -1,47 +1,47 @@
 package com.management.dto;
 
 public class PlayerResponseDTO {
-    private String id;
-    private String name;
-    private int points;
-    private int fouls;
+  private String id;
+  private String name;
+  private int points;
+  private int fouls;
 
-    public PlayerResponseDTO(String id, String name, int points, int fouls) {
-        this.id = id;
-        this.name = name;
-        this.points = points;
-        this.fouls = fouls;
-    }
+  public PlayerResponseDTO(String id, String name, int points, int fouls) {
+    this.id = id;
+    this.name = name;
+    this.points = points;
+    this.fouls = fouls;
+  }
 
-    public String getId() {
-        return id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public void setId(String id) {
-        this.id = id;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public int getPoints() {
-        return points;
-    }
+  public int getPoints() {
+    return points;
+  }
 
-    public void setPoints(int points) {
-        this.points = points;
-    }
+  public void setPoints(int points) {
+    this.points = points;
+  }
 
-    public int getFouls() {
-        return fouls;
-    }
+  public int getFouls() {
+    return fouls;
+  }
 
-    public void setFouls(int fouls) {
-        this.fouls = fouls;
-    }
+  public void setFouls(int fouls) {
+    this.fouls = fouls;
+  }
 }

--- a/src/main/java/com/management/enums/FoulTypes.java
+++ b/src/main/java/com/management/enums/FoulTypes.java
@@ -1,5 +1,10 @@
 package com.management.enums;
 
 public enum FoulTypes {
-    CHUI1, CHUI2, CHUI3, HANSOKU_CHUI, HANSOKU, SHIKKAKU
+  CHUI1,
+  CHUI2,
+  CHUI3,
+  HANSOKU_CHUI,
+  HANSOKU,
+  SHIKKAKU
 }

--- a/src/main/java/com/management/enums/GameState.java
+++ b/src/main/java/com/management/enums/GameState.java
@@ -1,8 +1,8 @@
 package com.management.enums;
 
 public enum GameState {
-    QUEUED,
-    RUNNING,
-    PAUSED,
-    FINISHED
+  QUEUED,
+  RUNNING,
+  PAUSED,
+  FINISHED
 }

--- a/src/main/java/com/management/enums/PlayerColor.java
+++ b/src/main/java/com/management/enums/PlayerColor.java
@@ -1,5 +1,6 @@
 package com.management.enums;
 
 public enum PlayerColor {
-    RED, BLUE
+  RED,
+  BLUE
 }

--- a/src/main/java/com/management/enums/PointsType.java
+++ b/src/main/java/com/management/enums/PointsType.java
@@ -6,17 +6,17 @@ import com.management.models.strategies.WazariStrategy;
 import com.management.models.strategies.YokoStrategy;
 
 public enum PointsType {
-    IPPON(new IpponStrategy()),
-    WAZARI(new WazariStrategy()),
-    YOKO(new YokoStrategy());
+  IPPON(new IpponStrategy()),
+  WAZARI(new WazariStrategy()),
+  YOKO(new YokoStrategy());
 
-    private final PointStrategy strategy;
+  private final PointStrategy strategy;
 
-    PointsType(PointStrategy strategy) {
-        this.strategy = strategy;
-    }
+  PointsType(PointStrategy strategy) {
+    this.strategy = strategy;
+  }
 
-    public PointStrategy getStrategy() {
-        return strategy;
-    }
+  public PointStrategy getStrategy() {
+    return strategy;
+  }
 }

--- a/src/main/java/com/management/exceptions/GameNotFoundException.java
+++ b/src/main/java/com/management/exceptions/GameNotFoundException.java
@@ -1,7 +1,7 @@
 package com.management.exceptions;
 
 public class GameNotFoundException extends RuntimeException {
-    public GameNotFoundException(String message){
-        super(message);
-    }
+  public GameNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
@@ -10,11 +10,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-  private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
-    logger.error("General Exception Caught: {} ", ex.getMessage());
+    log.error("General Exception Caught: {} ", ex.getMessage());
     ErrorResponse errorResponse =
         new ErrorResponse(
             HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error occurred.");
@@ -23,14 +23,14 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(PlayerNotFoundException.class)
   public ResponseEntity<ErrorResponse> handlePlayerNotFoundException(PlayerNotFoundException ex) {
-    logger.error("PlayerNotFoundException Caught: {} ", ex.getMessage());
+    log.error("PlayerNotFoundException Caught: {} ", ex.getMessage());
     ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
 
   @ExceptionHandler(GameNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleGameNotFoundException(GameNotFoundException ex) {
-    logger.error("handleGameNotFoundException Caught: {} ", ex.getMessage());
+    log.error("handleGameNotFoundException Caught: {} ", ex.getMessage());
     ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
@@ -38,7 +38,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(InvalidPlayerColorException.class)
   public ResponseEntity<ErrorResponse> handleInvalidPlayerColorException(
       InvalidPlayerColorException ex) {
-    logger.error("handleInvalidPlayerColorException Caught: {} ", ex.getMessage());
+    log.error("handleInvalidPlayerColorException Caught: {} ", ex.getMessage());
     ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
@@ -46,7 +46,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(PointTypeNotFoundException.class)
   public ResponseEntity<ErrorResponse> handlePointTypeNotFoundException(
       PointTypeNotFoundException ex) {
-    logger.error("handlePointTypeNotFoundException Caught: {} ", ex.getMessage());
+    log.error("handlePointTypeNotFoundException Caught: {} ", ex.getMessage());
     ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }

--- a/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
@@ -10,66 +10,70 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+  private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
-        logger.error("General Exception Caught: {} ", ex.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error occurred.");
-        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
+    logger.error("General Exception Caught: {} ", ex.getMessage());
+    ErrorResponse errorResponse =
+        new ErrorResponse(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error occurred.");
+    return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(PlayerNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handlePlayerNotFoundException(PlayerNotFoundException ex) {
+    logger.error("PlayerNotFoundException Caught: {} ", ex.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(GameNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleGameNotFoundException(GameNotFoundException ex) {
+    logger.error("handleGameNotFoundException Caught: {} ", ex.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(InvalidPlayerColorException.class)
+  public ResponseEntity<ErrorResponse> handleInvalidPlayerColorException(
+      InvalidPlayerColorException ex) {
+    logger.error("handleInvalidPlayerColorException Caught: {} ", ex.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(PointTypeNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handlePointTypeNotFoundException(
+      PointTypeNotFoundException ex) {
+    logger.error("handlePointTypeNotFoundException Caught: {} ", ex.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  public static class ErrorResponse {
+    private int status;
+    private String message;
+
+    public ErrorResponse(int status, String message) {
+      this.status = status;
+      this.message = message;
     }
 
-    @ExceptionHandler(PlayerNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handlePlayerNotFoundException(PlayerNotFoundException ex){
-        logger.error("PlayerNotFoundException Caught: {} ", ex.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    public int getStatus() {
+      return status;
     }
 
-    @ExceptionHandler(GameNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleGameNotFoundException(GameNotFoundException ex){
-        logger.error("handleGameNotFoundException Caught: {} ", ex.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    public void setStatus(int status) {
+      this.status = status;
     }
 
-    @ExceptionHandler(InvalidPlayerColorException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidPlayerColorException(InvalidPlayerColorException ex){
-        logger.error("handleInvalidPlayerColorException Caught: {} ", ex.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    public String getMessage() {
+      return message;
     }
 
-    @ExceptionHandler(PointTypeNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handlePointTypeNotFoundException(PointTypeNotFoundException ex){
-        logger.error("handlePointTypeNotFoundException Caught: {} ", ex.getMessage());
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    public void setMessage(String message) {
+      this.message = message;
     }
-
-    public static class ErrorResponse {
-        private int status;
-        private String message;
-
-        public ErrorResponse(int status, String message){
-            this.status = status;
-            this.message = message;
-        }
-
-        public int getStatus() {
-            return status;
-        }
-
-        public void setStatus(int status) {
-            this.status = status;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public void setMessage(String message) {
-            this.message = message;
-        }
-    }
+  }
 }

--- a/src/main/java/com/management/exceptions/InvalidPlayerColorException.java
+++ b/src/main/java/com/management/exceptions/InvalidPlayerColorException.java
@@ -1,7 +1,7 @@
 package com.management.exceptions;
 
 public class InvalidPlayerColorException extends RuntimeException {
-    public InvalidPlayerColorException(String message) {
-        super(message);
-    }
+  public InvalidPlayerColorException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/management/exceptions/PlayerNotFoundException.java
+++ b/src/main/java/com/management/exceptions/PlayerNotFoundException.java
@@ -1,7 +1,7 @@
 package com.management.exceptions;
 
 public class PlayerNotFoundException extends RuntimeException {
-    public PlayerNotFoundException(String message) {
-        super(message);
-    }
+  public PlayerNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/management/exceptions/PointTypeNotFoundException.java
+++ b/src/main/java/com/management/exceptions/PointTypeNotFoundException.java
@@ -1,7 +1,7 @@
 package com.management.exceptions;
 
 public class PointTypeNotFoundException extends RuntimeException {
-    public PointTypeNotFoundException(String message) {
-        super(message);
-    }
+  public PointTypeNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/management/kumitegame/KumiteGameStarter.java
+++ b/src/main/java/com/management/kumitegame/KumiteGameStarter.java
@@ -11,10 +11,10 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @SpringBootApplication(scanBasePackages = "com.management")
 @EnableMongoRepositories(basePackages = "com.management.repositories")
 public class KumiteGameStarter {
-  private static final Logger logger = LoggerFactory.getLogger(KumiteGameStarter.class);
+  private static final Logger log = LoggerFactory.getLogger(KumiteGameStarter.class);
 
   public static void main(String[] args) {
-    logger.info("Management - Kumite Management - Main - Started the application");
+    log.info("Management - Kumite Management - Main - Started the application");
     SpringApplication.run(KumiteGameStarter.class, args);
   }
 }

--- a/src/main/java/com/management/kumitegame/KumiteGameStarter.java
+++ b/src/main/java/com/management/kumitegame/KumiteGameStarter.java
@@ -6,14 +6,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-//@RestController
-//@RequestMapping("/api")
+// @RestController
+// @RequestMapping("/api")
 @SpringBootApplication(scanBasePackages = "com.management")
 @EnableMongoRepositories(basePackages = "com.management.repositories")
 public class KumiteGameStarter {
-    private static final Logger logger = LoggerFactory.getLogger(KumiteGameStarter.class);
-    public static void main(String[] args) {
-        logger.info("Management - Kumite Management - Main - Started the application");
-        SpringApplication.run(KumiteGameStarter.class, args);
-    }
+  private static final Logger logger = LoggerFactory.getLogger(KumiteGameStarter.class);
+
+  public static void main(String[] args) {
+    logger.info("Management - Kumite Management - Main - Started the application");
+    SpringApplication.run(KumiteGameStarter.class, args);
+  }
 }

--- a/src/main/java/com/management/models/Foul.java
+++ b/src/main/java/com/management/models/Foul.java
@@ -1,25 +1,25 @@
 package com.management.models;
 
 public class Foul {
-    private int numOfFouls;
+  private int numOfFouls;
 
-    public Foul(){
-        this.numOfFouls = 0;
-    }
+  public Foul() {
+    this.numOfFouls = 0;
+  }
 
-    public void addFoul(){
-        this.setNumOfFouls(this.getNumOfFouls() + 1);
-    }
+  public void addFoul() {
+    this.setNumOfFouls(this.getNumOfFouls() + 1);
+  }
 
-    public void removeFoul() {
-        this.setNumOfFouls(Math.max(this.getNumOfFouls() - 1, 0));
-    }
+  public void removeFoul() {
+    this.setNumOfFouls(Math.max(this.getNumOfFouls() - 1, 0));
+  }
 
-    public int getNumOfFouls(){
-        return numOfFouls;
-    }
+  public int getNumOfFouls() {
+    return numOfFouls;
+  }
 
-    public void setNumOfFouls(int numOfFouls) {
-        this.numOfFouls = numOfFouls;
-    }
+  public void setNumOfFouls(int numOfFouls) {
+    this.numOfFouls = numOfFouls;
+  }
 }

--- a/src/main/java/com/management/models/GameTimer.java
+++ b/src/main/java/com/management/models/GameTimer.java
@@ -4,41 +4,41 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 
 public class GameTimer {
-    private LocalDateTime startTime;
-    private Duration remainingTime;
+  private LocalDateTime startTime;
+  private Duration remainingTime;
 
-    public GameTimer(Duration initialDuration) {
-        this.remainingTime = initialDuration;
-    }
+  public GameTimer(Duration initialDuration) {
+    this.remainingTime = initialDuration;
+  }
 
-    public void start() {
-        this.startTime = LocalDateTime.now();
-    }
+  public void start() {
+    this.startTime = LocalDateTime.now();
+  }
 
-    public void pause() {
-        if (startTime != null) {
-            Duration elapsedTime = Duration.between(startTime, LocalDateTime.now());
-            this.remainingTime = remainingTime.minus(elapsedTime);
-            this.startTime = null;
-        }
+  public void pause() {
+    if (startTime != null) {
+      Duration elapsedTime = Duration.between(startTime, LocalDateTime.now());
+      this.remainingTime = remainingTime.minus(elapsedTime);
+      this.startTime = null;
     }
+  }
 
-    public void resume() {
-        if (startTime == null) {
-            this.startTime = LocalDateTime.now();
-        }
+  public void resume() {
+    if (startTime == null) {
+      this.startTime = LocalDateTime.now();
     }
+  }
 
-    public void stop() {
-        this.remainingTime = Duration.ZERO;
-        this.startTime = null;
-    }
+  public void stop() {
+    this.remainingTime = Duration.ZERO;
+    this.startTime = null;
+  }
 
-    public Duration getRemainingTime() {
-        if (startTime != null) {
-            Duration elapsedTime = Duration.between(startTime, LocalDateTime.now());
-            return remainingTime.minus(elapsedTime);
-        }
-        return remainingTime;
+  public Duration getRemainingTime() {
+    if (startTime != null) {
+      Duration elapsedTime = Duration.between(startTime, LocalDateTime.now());
+      return remainingTime.minus(elapsedTime);
     }
+    return remainingTime;
+  }
 }

--- a/src/main/java/com/management/models/KumiteGame.java
+++ b/src/main/java/com/management/models/KumiteGame.java
@@ -26,7 +26,7 @@ public class KumiteGame {
   private Duration gameDuration;
   @JsonIgnore @Transient private GameTimer timer;
 
-  private static final Logger logger = LoggerFactory.getLogger(KumiteGame.class);
+  private static final Logger log = LoggerFactory.getLogger(KumiteGame.class);
   private static final String PLAYER_COLOR_NOT_FOUND = "Player color not found in the game";
   private static final String PLAYER_COLOR = " Player color: ";
 
@@ -46,7 +46,7 @@ public class KumiteGame {
 
   public void updatePlayer(PlayerColor color, Player updatedPlayer) {
     if (!(playersMap.containsKey(color))) {
-      logger.error(
+      log.error(
           "KumiteGame - updatePlayer - {}, {}}: {}", PLAYER_COLOR_NOT_FOUND, PLAYER_COLOR, color);
       throw new PlayerNotFoundException(PLAYER_COLOR_NOT_FOUND + PLAYER_COLOR + color);
     }
@@ -55,7 +55,7 @@ public class KumiteGame {
 
   public void updateWinner(PlayerColor color) {
     if (!(playersMap.containsKey(color))) {
-      logger.error(
+      log.error(
           "KumiteGame - updateWinner - {}, {}}: {}", PLAYER_COLOR_NOT_FOUND, PLAYER_COLOR, color);
       throw new PlayerNotFoundException(PLAYER_COLOR_NOT_FOUND + PLAYER_COLOR + color);
     }

--- a/src/main/java/com/management/models/KumiteGame.java
+++ b/src/main/java/com/management/models/KumiteGame.java
@@ -4,114 +4,126 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.management.enums.GameState;
 import com.management.enums.PlayerColor;
 import com.management.exceptions.PlayerNotFoundException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-
 @Document
 public class KumiteGame {
-    @Id
-    private String id;
-    private GameState gameState;
-    private Map<PlayerColor, Player> playersMap;
-    private List<Referee> referees;
-    private String winner;
-    private LocalDateTime startTime;
-    private Duration remainingTime;
-    private Duration gameDuration;
-    @JsonIgnore
-    @Transient
-    private GameTimer timer;
+  @Id private String id;
+  private GameState gameState;
+  private Map<PlayerColor, Player> playersMap;
+  private List<Referee> referees;
+  private String winner;
+  private LocalDateTime startTime;
+  private Duration remainingTime;
+  private Duration gameDuration;
+  @JsonIgnore @Transient private GameTimer timer;
 
-    private static final Logger logger = LoggerFactory.getLogger(KumiteGame.class);
-    private static final String PLAYER_COLOR_NOT_FOUND = "Player color not found in the game";
-    private static final String PLAYER_COLOR = " Player color: ";
+  private static final Logger logger = LoggerFactory.getLogger(KumiteGame.class);
+  private static final String PLAYER_COLOR_NOT_FOUND = "Player color not found in the game";
+  private static final String PLAYER_COLOR = " Player color: ";
 
-    public KumiteGame(Map<PlayerColor, Player> playersMap, List<Referee> referees, Duration gameDuration) {
-        this.gameState = GameState.QUEUED;
-        this.playersMap = playersMap;
-        this.referees = referees;
-        this.gameDuration = gameDuration;
-        this.remainingTime = gameDuration;
-        this.winner = "Pending game ending";
+  public KumiteGame(
+      Map<PlayerColor, Player> playersMap, List<Referee> referees, Duration gameDuration) {
+    this.gameState = GameState.QUEUED;
+    this.playersMap = playersMap;
+    this.referees = referees;
+    this.gameDuration = gameDuration;
+    this.remainingTime = gameDuration;
+    this.winner = "Pending game ending";
+  }
+
+  public void initializeTimer(Duration gameDuration) {
+    this.timer = new GameTimer(gameDuration);
+  }
+
+  public void updatePlayer(PlayerColor color, Player updatedPlayer) {
+    if (!(playersMap.containsKey(color))) {
+      logger.error(
+          "KumiteGame - updatePlayer - {}, {}}: {}", PLAYER_COLOR_NOT_FOUND, PLAYER_COLOR, color);
+      throw new PlayerNotFoundException(PLAYER_COLOR_NOT_FOUND + PLAYER_COLOR + color);
     }
+    playersMap.put(color, updatedPlayer);
+  }
 
-    public void initializeTimer(Duration gameDuration) {
-        this.timer = new GameTimer(gameDuration);
+  public void updateWinner(PlayerColor color) {
+    if (!(playersMap.containsKey(color))) {
+      logger.error(
+          "KumiteGame - updateWinner - {}, {}}: {}", PLAYER_COLOR_NOT_FOUND, PLAYER_COLOR, color);
+      throw new PlayerNotFoundException(PLAYER_COLOR_NOT_FOUND + PLAYER_COLOR + color);
     }
+    String gameWinner = color.name() + " player: " + playersMap.get(color).getName();
+    setWinner(gameWinner);
+  }
 
-    public void updatePlayer(PlayerColor color, Player updatedPlayer){
-        if (!(playersMap.containsKey(color))) {
-            logger.error("KumiteGame - updatePlayer - {}, {}}: {}", PLAYER_COLOR_NOT_FOUND, PLAYER_COLOR, color);
-            throw new PlayerNotFoundException(PLAYER_COLOR_NOT_FOUND + PLAYER_COLOR + color);
-        }
-        playersMap.put(color, updatedPlayer);
-    }
+  public String getId() {
+    return id;
+  }
 
-    public void updateWinner(PlayerColor color){
-        if (!(playersMap.containsKey(color))){
-            logger.error("KumiteGame - updateWinner - {}, {}}: {}", PLAYER_COLOR_NOT_FOUND, PLAYER_COLOR, color);
-            throw new PlayerNotFoundException(PLAYER_COLOR_NOT_FOUND + PLAYER_COLOR + color);
-        }
-        String gameWinner = color.name() + " player: " + playersMap.get(color).getName();
-        setWinner(gameWinner);
-    }
+  public GameState getGameState() {
+    return gameState;
+  }
 
-    public String getId(){
-        return id;
-    }
+  public void setGameState(GameState gameState) {
+    this.gameState = gameState;
+  }
 
-    public GameState getGameState() {
-        return gameState;
-    }
+  public Map<PlayerColor, Player> getPlayersMap() {
+    return playersMap;
+  }
 
-    public void setGameState(GameState gameState) {
-        this.gameState = gameState;
-    }
+  public void setPlayersMap(Map<PlayerColor, Player> playersMap) {
+    this.playersMap = playersMap;
+  }
 
-    public Map<PlayerColor, Player> getPlayersMap() {
-        return playersMap;
-    }
+  public List<Referee> getReferees() {
+    return referees;
+  }
 
-    public void setPlayersMap(Map<PlayerColor, Player> playersMap) {
-        this.playersMap = playersMap;
-    }
+  public void setReferees(List<Referee> referees) {
+    this.referees = referees;
+  }
 
-    public List<Referee> getReferees() {
-        return referees;
-    }
+  public String getWinner() {
+    return winner;
+  }
 
-    public void setReferees(List<Referee> referees) {
-        this.referees = referees;
-    }
+  public void setWinner(String winner) {
+    this.winner = winner;
+  }
 
-    public String getWinner() {
-        return winner;
-    }
+  public void setStartTime(LocalDateTime startTime) {
+    this.startTime = startTime;
+  }
 
-    public void setWinner(String winner) {
-        this.winner = winner;
-    }
+  public LocalDateTime getStartTime() {
+    return startTime;
+  }
 
-    public void setStartTime(LocalDateTime startTime) { this.startTime = startTime; }
-    public LocalDateTime getStartTime() { return startTime; }
-    public Duration getRemainingTime() { return remainingTime; }
+  public Duration getRemainingTime() {
+    return remainingTime;
+  }
 
-    public void setRemainingTime(Duration remainingTime) {
-        this.remainingTime = remainingTime;
-    }
+  public void setRemainingTime(Duration remainingTime) {
+    this.remainingTime = remainingTime;
+  }
 
-    public Duration getGameDuration() { return gameDuration; }
-    public void setGameDuration(Duration gameDuration) { this.gameDuration = gameDuration; }
+  public Duration getGameDuration() {
+    return gameDuration;
+  }
 
-    public GameTimer getTimer() {
-        return timer;
-    }
+  public void setGameDuration(Duration gameDuration) {
+    this.gameDuration = gameDuration;
+  }
+
+  public GameTimer getTimer() {
+    return timer;
+  }
 }

--- a/src/main/java/com/management/models/Player.java
+++ b/src/main/java/com/management/models/Player.java
@@ -6,68 +6,71 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document
 public class Player {
-    @Id
-    private String id;
-    private String name;
-    private Points points;
-    private Foul fouls;
+  @Id private String id;
+  private String name;
+  private Points points;
+  private Foul fouls;
 
-    public Player() {}
-    public Player(String name){
-        this.name = name;
-        this.points = new Points();
-        this.fouls = new Foul();
-    }
-    public Player(String id, String name, Points points, Foul fouls) {
-        this.id = id;
-        this.name = name;
-        this.points = points;
-        this.fouls = fouls;
-    }
+  public Player() {}
 
-    public String getId() {
-        return id;
-    }
-    public void setId(String id) { this.id = id; }
+  public Player(String name) {
+    this.name = name;
+    this.points = new Points();
+    this.fouls = new Foul();
+  }
 
-    public String getName() {
-        return name;
-    }
+  public Player(String id, String name, Points points, Foul fouls) {
+    this.id = id;
+    this.name = name;
+    this.points = points;
+    this.fouls = fouls;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public Points getPoints() {
-        return points;
-    }
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    public void setPoints(Points points){
-        this.points = points;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public Foul getFouls(){
-        return this.fouls;
-    }
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    public void setFouls(Foul fouls){
-        this.fouls = fouls;
-    }
+  public Points getPoints() {
+    return points;
+  }
 
-    public void addPoint(PointsType pointType) {
-        pointType.getStrategy().addPoint(this.points);
-    }
+  public void setPoints(Points points) {
+    this.points = points;
+  }
 
-    public void removePoint(PointsType pointType){
-        pointType.getStrategy().removePoint(this.points);
-    }
+  public Foul getFouls() {
+    return this.fouls;
+  }
 
-    public void addFoul() {
-        this.fouls.addFoul();
-    }
+  public void setFouls(Foul fouls) {
+    this.fouls = fouls;
+  }
 
-    public void removeFoul() {
-        this.fouls.removeFoul();
-    }
+  public void addPoint(PointsType pointType) {
+    pointType.getStrategy().addPoint(this.points);
+  }
 
+  public void removePoint(PointsType pointType) {
+    pointType.getStrategy().removePoint(this.points);
+  }
+
+  public void addFoul() {
+    this.fouls.addFoul();
+  }
+
+  public void removeFoul() {
+    this.fouls.removeFoul();
+  }
 }

--- a/src/main/java/com/management/models/Points.java
+++ b/src/main/java/com/management/models/Points.java
@@ -1,17 +1,17 @@
 package com.management.models;
 
 public class Points {
-    private int numOfPoints;
+  private int numOfPoints;
 
-    public Points(){
-        this.numOfPoints = 0;
-    }
+  public Points() {
+    this.numOfPoints = 0;
+  }
 
-    public int getNumOfPoints(){
-        return numOfPoints;
-    }
+  public int getNumOfPoints() {
+    return numOfPoints;
+  }
 
-    public void setNumOfPoints(int numOfPoints) {
-        this.numOfPoints = numOfPoints;
-    }
+  public void setNumOfPoints(int numOfPoints) {
+    this.numOfPoints = numOfPoints;
+  }
 }

--- a/src/main/java/com/management/models/Referee.java
+++ b/src/main/java/com/management/models/Referee.java
@@ -1,4 +1,3 @@
 package com.management.models;
 
-public record Referee(String name) {
-}
+public record Referee(String name) {}

--- a/src/main/java/com/management/models/strategies/IpponStrategy.java
+++ b/src/main/java/com/management/models/strategies/IpponStrategy.java
@@ -3,10 +3,13 @@ package com.management.models.strategies;
 import com.management.models.Points;
 
 public class IpponStrategy implements PointStrategy {
-    @Override
-    public void addPoint(Points point) {
-        point.setNumOfPoints(point.getNumOfPoints() + 3);
-    }
-    @Override
-    public void removePoint(Points point) { point.setNumOfPoints(Math.max(point.getNumOfPoints() - 3, 0));}
+  @Override
+  public void addPoint(Points point) {
+    point.setNumOfPoints(point.getNumOfPoints() + 3);
+  }
+
+  @Override
+  public void removePoint(Points point) {
+    point.setNumOfPoints(Math.max(point.getNumOfPoints() - 3, 0));
+  }
 }

--- a/src/main/java/com/management/models/strategies/PointStrategy.java
+++ b/src/main/java/com/management/models/strategies/PointStrategy.java
@@ -3,6 +3,7 @@ package com.management.models.strategies;
 import com.management.models.Points;
 
 public interface PointStrategy {
-    void addPoint(Points point);
-    void removePoint(Points point);
+  void addPoint(Points point);
+
+  void removePoint(Points point);
 }

--- a/src/main/java/com/management/models/strategies/WazariStrategy.java
+++ b/src/main/java/com/management/models/strategies/WazariStrategy.java
@@ -3,10 +3,13 @@ package com.management.models.strategies;
 import com.management.models.Points;
 
 public class WazariStrategy implements PointStrategy {
-    @Override
-    public void addPoint(Points point) {
-        point.setNumOfPoints(point.getNumOfPoints() + 2);
-    }
-    @Override
-    public void removePoint(Points point) { point.setNumOfPoints(Math.max(point.getNumOfPoints() - 2, 0));}
+  @Override
+  public void addPoint(Points point) {
+    point.setNumOfPoints(point.getNumOfPoints() + 2);
+  }
+
+  @Override
+  public void removePoint(Points point) {
+    point.setNumOfPoints(Math.max(point.getNumOfPoints() - 2, 0));
+  }
 }

--- a/src/main/java/com/management/models/strategies/YokoStrategy.java
+++ b/src/main/java/com/management/models/strategies/YokoStrategy.java
@@ -3,10 +3,13 @@ package com.management.models.strategies;
 import com.management.models.Points;
 
 public class YokoStrategy implements PointStrategy {
-    @Override
-    public void addPoint(Points point) {
-        point.setNumOfPoints(point.getNumOfPoints() + 1);
-    }
-    @Override
-    public void removePoint(Points point) { point.setNumOfPoints(Math.max(point.getNumOfPoints() - 1, 0));}
+  @Override
+  public void addPoint(Points point) {
+    point.setNumOfPoints(point.getNumOfPoints() + 1);
+  }
+
+  @Override
+  public void removePoint(Points point) {
+    point.setNumOfPoints(Math.max(point.getNumOfPoints() - 1, 0));
+  }
 }

--- a/src/main/java/com/management/repositories/KumiteGameRepository.java
+++ b/src/main/java/com/management/repositories/KumiteGameRepository.java
@@ -3,6 +3,4 @@ package com.management.repositories;
 import com.management.models.KumiteGame;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface KumiteGameRepository extends MongoRepository<KumiteGame, String> {
-
-}
+public interface KumiteGameRepository extends MongoRepository<KumiteGame, String> {}

--- a/src/main/java/com/management/repositories/PlayerRepository.java
+++ b/src/main/java/com/management/repositories/PlayerRepository.java
@@ -1,8 +1,6 @@
 package com.management.repositories;
 
-import org.springframework.data.mongodb.repository.MongoRepository;
 import com.management.models.Player;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface PlayerRepository extends MongoRepository<Player, String> {
-
-}
+public interface PlayerRepository extends MongoRepository<Player, String> {}

--- a/src/main/java/com/management/services/GameHelperService.java
+++ b/src/main/java/com/management/services/GameHelperService.java
@@ -11,26 +11,24 @@ import org.springframework.stereotype.Service;
 @Service
 public class GameHelperService {
 
+  @Autowired private KumiteGameService kumiteGameService;
+  @Autowired private PlayerService playerService;
 
-    @Autowired
-    private KumiteGameService kumiteGameService;
-    @Autowired
-    private PlayerService playerService;
-    public String getPlayerIdByGameAndColor(String gameId, String color){
-        KumiteGame kumiteGame = kumiteGameService.getKumiteGame(gameId);
-        PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
-        return kumiteGame.getPlayersMap().get(playerColor).getId();
-    }
+  public String getPlayerIdByGameAndColor(String gameId, String color) {
+    KumiteGame kumiteGame = kumiteGameService.getKumiteGame(gameId);
+    PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
+    return kumiteGame.getPlayersMap().get(playerColor).getId();
+  }
 
-    public void updateKumiteGame(String gameId, String color) {
-        kumiteGameService.updateKumiteGamePlayers(gameId, color);
-    }
+  public void updateKumiteGame(String gameId, String color) {
+    kumiteGameService.updateKumiteGamePlayers(gameId, color);
+  }
 
-    public Player getPlayerById(String playerId) {
-        return playerService.getPlayer(playerId);
-    }
+  public Player getPlayerById(String playerId) {
+    return playerService.getPlayer(playerId);
+  }
 
-    public Player createNewPlayer(PlayerRequestDTO playerDTO) {
-        return playerService.createPlayer(playerDTO);
-    }
+  public Player createNewPlayer(PlayerRequestDTO playerDTO) {
+    return playerService.createPlayer(playerDTO);
+  }
 }

--- a/src/main/java/com/management/services/KumiteGameService.java
+++ b/src/main/java/com/management/services/KumiteGameService.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class KumiteGameService {
 
-  private static final Logger logger = LoggerFactory.getLogger(KumiteGameService.class);
+  private static final Logger log = LoggerFactory.getLogger(KumiteGameService.class);
   private static final String GAME_NOT_FOUND = "Game not found!";
   private static final String GAME_ID = " Game Id: ";
   @Autowired private KumiteGameRepository kumiteGameRepository;
@@ -105,7 +105,7 @@ public class KumiteGameService {
 
     Optional<KumiteGame> fetchedKumiteGame = kumiteGameRepository.findById(gameId);
     if (fetchedKumiteGame.isEmpty()) {
-      logger.error("KumiteGameService - getKumiteGame - couldn't find game with id: {}", gameId);
+      log.error("KumiteGameService - getKumiteGame - couldn't find game with id: {}", gameId);
       throw new GameNotFoundException(GAME_NOT_FOUND + GAME_ID + gameId);
     }
 
@@ -153,7 +153,7 @@ public class KumiteGameService {
   }
 
   private KumiteGame saveGame(KumiteGame kumiteGame) {
-    logger.debug("Saving game with ID: {}", kumiteGame.getId());
+    log.debug("Saving game with ID: {}", kumiteGame.getId());
     return kumiteGameRepository.save(kumiteGame);
   }
 }

--- a/src/main/java/com/management/services/KumiteGameService.java
+++ b/src/main/java/com/management/services/KumiteGameService.java
@@ -11,148 +11,149 @@ import com.management.models.Referee;
 import com.management.repositories.KumiteGameRepository;
 import com.management.util.GameConfig;
 import com.management.util.KumiteGameManagementUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Service;
-
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
 
 @Service
 public class KumiteGameService {
 
-    private static final Logger logger = LoggerFactory.getLogger(KumiteGameService.class);
-    private static final String GAME_NOT_FOUND = "Game not found!";
-    private static final String GAME_ID = " Game Id: ";
-    @Autowired
-    private KumiteGameRepository kumiteGameRepository;
+  private static final Logger logger = LoggerFactory.getLogger(KumiteGameService.class);
+  private static final String GAME_NOT_FOUND = "Game not found!";
+  private static final String GAME_ID = " Game Id: ";
+  @Autowired private KumiteGameRepository kumiteGameRepository;
 
-    private final GameConfig config = new GameConfig();
-    @Autowired
-    @Lazy
-    private GameHelperService gameHelperService;
+  private final GameConfig config = new GameConfig();
+  @Autowired @Lazy private GameHelperService gameHelperService;
 
-    public KumiteGame createKumiteGame(KumiteGameRequestDTO gameRequestDTO) {
+  public KumiteGame createKumiteGame(KumiteGameRequestDTO gameRequestDTO) {
 
-        validateGameRequestDTO(gameRequestDTO);
-        Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
+    validateGameRequestDTO(gameRequestDTO);
+    Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
 
-        gameRequestDTO.getPlayersMap().forEach((key, playerDTO) -> {
-            PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(playerDTO.getColor());
-            PlayerRequestDTO playerRequestDTO = new PlayerRequestDTO();
-            playerRequestDTO.setName(playerDTO.getName());
-            Player player = gameHelperService.createNewPlayer(playerRequestDTO);
-            playersMap.put(playerColor, player);
-        });
+    gameRequestDTO
+        .getPlayersMap()
+        .forEach(
+            (key, playerDTO) -> {
+              PlayerColor playerColor =
+                  KumiteGameManagementUtils.mapPlayerColor(playerDTO.getColor());
+              PlayerRequestDTO playerRequestDTO = new PlayerRequestDTO();
+              playerRequestDTO.setName(playerDTO.getName());
+              Player player = gameHelperService.createNewPlayer(playerRequestDTO);
+              playersMap.put(playerColor, player);
+            });
 
-        List<Referee> refereesList = gameRequestDTO.getRefereeList().stream().map(Referee::new).toList();
+    List<Referee> refereesList =
+        gameRequestDTO.getRefereeList().stream().map(Referee::new).toList();
 
-        Duration gameDuration = determineGameDuration(gameRequestDTO);
+    Duration gameDuration = determineGameDuration(gameRequestDTO);
 
-        KumiteGame kumiteGame = new KumiteGame(playersMap, refereesList, gameDuration);
+    KumiteGame kumiteGame = new KumiteGame(playersMap, refereesList, gameDuration);
 
-        return saveGame(kumiteGame);
+    return saveGame(kumiteGame);
+  }
+
+  public KumiteGame startGame(String gameId) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    kumiteGame.initializeTimer(kumiteGame.getRemainingTime());
+    kumiteGame.setGameState(GameState.RUNNING);
+    kumiteGame.setStartTime(LocalDateTime.now());
+    kumiteGame.getTimer().start();
+    updateRemainingTime(kumiteGame);
+    return saveGame(kumiteGame);
+  }
+
+  public KumiteGame pauseGame(String gameId) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    kumiteGame.getTimer().pause();
+    updateRemainingTime(kumiteGame);
+    kumiteGame.setStartTime(null);
+    kumiteGame.setGameState(GameState.PAUSED);
+    return saveGame(kumiteGame);
+  }
+
+  public KumiteGame resumeGame(String gameId) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    kumiteGame.initializeTimer(kumiteGame.getRemainingTime());
+    kumiteGame.setGameState(GameState.RUNNING);
+    kumiteGame.setStartTime(LocalDateTime.now());
+    kumiteGame.getTimer().resume();
+    return saveGame(kumiteGame);
+  }
+
+  public KumiteGame endGame(String gameId) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    kumiteGame.getTimer().stop();
+    updateRemainingTime(kumiteGame);
+    kumiteGame.setGameState(GameState.FINISHED);
+    return saveGame(kumiteGame);
+  }
+
+  private void updateRemainingTime(KumiteGame kumiteGame) {
+    kumiteGame.setRemainingTime(kumiteGame.getTimer().getRemainingTime());
+  }
+
+  public KumiteGame getKumiteGame(String gameId) {
+
+    Optional<KumiteGame> fetchedKumiteGame = kumiteGameRepository.findById(gameId);
+    if (fetchedKumiteGame.isEmpty()) {
+      logger.error("KumiteGameService - getKumiteGame - couldn't find game with id: {}", gameId);
+      throw new GameNotFoundException(GAME_NOT_FOUND + GAME_ID + gameId);
     }
 
-    public KumiteGame startGame(String gameId) {
-        KumiteGame kumiteGame = getKumiteGame(gameId);
-        kumiteGame.initializeTimer(kumiteGame.getRemainingTime());
-        kumiteGame.setGameState(GameState.RUNNING);
-        kumiteGame.setStartTime(LocalDateTime.now());
-        kumiteGame.getTimer().start();
-        updateRemainingTime(kumiteGame);
-        return saveGame(kumiteGame);
+    return fetchedKumiteGame.get();
+  }
+
+  public KumiteGame updateKumiteGamePlayers(String gameId, String color) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
+
+    String playerId = kumiteGame.getPlayersMap().get(playerColor).getId();
+    Player updatedPlayer = gameHelperService.getPlayerById(playerId);
+
+    kumiteGame.updatePlayer(playerColor, updatedPlayer);
+    return saveGame(kumiteGame);
+  }
+
+  public KumiteGame updateKumiteGameWinner(String gameId, String color) {
+
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
+    kumiteGame.updateWinner(playerColor);
+
+    return saveGame(kumiteGame);
+  }
+
+  private void validateGameRequestDTO(KumiteGameRequestDTO gameRequestDTO) {
+    if (gameRequestDTO.getPlayersMap() == null || gameRequestDTO.getPlayersMap().isEmpty()) {
+      throw new IllegalArgumentException("Players cannot be empty");
     }
-
-    public KumiteGame pauseGame(String gameId) {
-        KumiteGame kumiteGame = getKumiteGame(gameId);
-        kumiteGame.getTimer().pause();
-        updateRemainingTime(kumiteGame);
-        kumiteGame.setStartTime(null);
-        kumiteGame.setGameState(GameState.PAUSED);
-        return saveGame(kumiteGame);
+    if (gameRequestDTO.getRefereeList() == null || gameRequestDTO.getRefereeList().isEmpty()) {
+      throw new IllegalArgumentException("Referee list cannot be empty");
     }
+  }
 
-    public KumiteGame resumeGame(String gameId) {
-        KumiteGame kumiteGame = getKumiteGame(gameId);
-        kumiteGame.initializeTimer(kumiteGame.getRemainingTime());
-        kumiteGame.setGameState(GameState.RUNNING);
-        kumiteGame.setStartTime(LocalDateTime.now());
-        kumiteGame.getTimer().resume();
-        return saveGame(kumiteGame);
+  private Duration determineGameDuration(KumiteGameRequestDTO gameRequestDTO) {
+    if (gameRequestDTO.getGameDuration() != null) {
+      Duration requestedDuration =
+          Duration.ofSeconds(Integer.parseInt(gameRequestDTO.getGameDuration()));
+      if (config.getOptionalDurations().contains(requestedDuration)) {
+        return requestedDuration;
+      }
     }
+    return config.getDefaultDuration();
+  }
 
-    public KumiteGame endGame(String gameId) {
-        KumiteGame kumiteGame = getKumiteGame(gameId);
-        kumiteGame.getTimer().stop();
-        updateRemainingTime(kumiteGame);
-        kumiteGame.setGameState(GameState.FINISHED);
-        return saveGame(kumiteGame);
-    }
-
-    private void updateRemainingTime(KumiteGame kumiteGame) {
-        kumiteGame.setRemainingTime(kumiteGame.getTimer().getRemainingTime());
-    }
-
-    public KumiteGame getKumiteGame(String gameId){
-
-        Optional<KumiteGame> fetchedKumiteGame = kumiteGameRepository.findById(gameId);
-        if (fetchedKumiteGame.isEmpty()){
-            logger.error("KumiteGameService - getKumiteGame - couldn't find game with id: {}", gameId);
-            throw new GameNotFoundException(GAME_NOT_FOUND + GAME_ID + gameId);
-        }
-
-        return fetchedKumiteGame.get();
-    }
-
-    public KumiteGame updateKumiteGamePlayers(String gameId, String color){
-        KumiteGame kumiteGame = getKumiteGame(gameId);
-        PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
-
-        String playerId = kumiteGame.getPlayersMap().get(playerColor).getId();
-        Player updatedPlayer = gameHelperService.getPlayerById(playerId);
-
-        kumiteGame.updatePlayer(playerColor, updatedPlayer);
-        return saveGame(kumiteGame);
-    }
-
-    public KumiteGame updateKumiteGameWinner(String gameId, String color){
-
-        KumiteGame kumiteGame = getKumiteGame(gameId);
-        PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
-        kumiteGame.updateWinner(playerColor);
-
-
-        return saveGame(kumiteGame);
-    }
-
-    private void validateGameRequestDTO(KumiteGameRequestDTO gameRequestDTO) {
-        if (gameRequestDTO.getPlayersMap() == null || gameRequestDTO.getPlayersMap().isEmpty()) {
-            throw new IllegalArgumentException("Players cannot be empty");
-        }
-        if (gameRequestDTO.getRefereeList() == null || gameRequestDTO.getRefereeList().isEmpty()) {
-            throw new IllegalArgumentException("Referee list cannot be empty");
-        }
-    }
-
-    private Duration determineGameDuration(KumiteGameRequestDTO gameRequestDTO) {
-        if (gameRequestDTO.getGameDuration() != null) {
-            Duration requestedDuration = Duration.ofSeconds(Integer.parseInt(gameRequestDTO.getGameDuration()));
-            if (config.getOptionalDurations().contains(requestedDuration)) {
-                return requestedDuration;
-            }
-        }
-        return config.getDefaultDuration();
-    }
-
-    private KumiteGame saveGame(KumiteGame kumiteGame) {
-        logger.debug("Saving game with ID: {}", kumiteGame.getId());
-        return kumiteGameRepository.save(kumiteGame);
-    }
+  private KumiteGame saveGame(KumiteGame kumiteGame) {
+    logger.debug("Saving game with ID: {}", kumiteGame.getId());
+    return kumiteGameRepository.save(kumiteGame);
+  }
 }

--- a/src/main/java/com/management/services/PlayerService.java
+++ b/src/main/java/com/management/services/PlayerService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class PlayerService {
-  private static final Logger logger = LoggerFactory.getLogger(PlayerService.class);
+  private static final Logger log = LoggerFactory.getLogger(PlayerService.class);
   private static final String PLAYER_NOT_FOUND = "Player not found";
   private static final String PLAYER_ID = " Player ID: ";
   @Autowired private PlayerRepository playerRepository;
@@ -29,7 +29,7 @@ public class PlayerService {
   public Player getPlayer(String playerId) {
     Optional<Player> fetchedPlayer = playerRepository.findById(playerId);
     if (fetchedPlayer.isEmpty()) {
-      logger.error("PlayerService - getPlayer - {}  {}: {}", PLAYER_NOT_FOUND, PLAYER_ID, playerId);
+      log.error("PlayerService - getPlayer - {}  {}: {}", PLAYER_NOT_FOUND, PLAYER_ID, playerId);
       throw new PlayerNotFoundException(PLAYER_NOT_FOUND + PLAYER_ID + playerId);
     }
     return fetchedPlayer.get();

--- a/src/main/java/com/management/services/PlayerService.java
+++ b/src/main/java/com/management/services/PlayerService.java
@@ -6,90 +6,84 @@ import com.management.exceptions.PlayerNotFoundException;
 import com.management.models.Player;
 import com.management.repositories.PlayerRepository;
 import com.management.util.KumiteGameManagementUtils;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
-
 @Service
 public class PlayerService {
-    private static final Logger logger = LoggerFactory.getLogger(PlayerService.class);
-    private static final String PLAYER_NOT_FOUND = "Player not found";
-    private static final String PLAYER_ID = " Player ID: ";
-    @Autowired
-    private PlayerRepository playerRepository;
-    @Autowired
-    @Lazy
-    private GameHelperService gameHelperService;
+  private static final Logger logger = LoggerFactory.getLogger(PlayerService.class);
+  private static final String PLAYER_NOT_FOUND = "Player not found";
+  private static final String PLAYER_ID = " Player ID: ";
+  @Autowired private PlayerRepository playerRepository;
+  @Autowired @Lazy private GameHelperService gameHelperService;
 
-    public Player createPlayer(PlayerRequestDTO playerDTO) {
-        Player newPlayer = new Player(playerDTO.getName());
-        return playerRepository.save(newPlayer);
+  public Player createPlayer(PlayerRequestDTO playerDTO) {
+    Player newPlayer = new Player(playerDTO.getName());
+    return playerRepository.save(newPlayer);
+  }
+
+  public Player getPlayer(String playerId) {
+    Optional<Player> fetchedPlayer = playerRepository.findById(playerId);
+    if (fetchedPlayer.isEmpty()) {
+      logger.error("PlayerService - getPlayer - {}  {}: {}", PLAYER_NOT_FOUND, PLAYER_ID, playerId);
+      throw new PlayerNotFoundException(PLAYER_NOT_FOUND + PLAYER_ID + playerId);
     }
+    return fetchedPlayer.get();
+  }
 
-    public Player getPlayer(String playerId) {
-        Optional<Player> fetchedPlayer = playerRepository.findById(playerId);
-        if (fetchedPlayer.isEmpty()){
-            logger.error("PlayerService - getPlayer - {}  {}: {}", PLAYER_NOT_FOUND, PLAYER_ID, playerId);
-            throw new PlayerNotFoundException(PLAYER_NOT_FOUND + PLAYER_ID + playerId);
-        }
-        return fetchedPlayer.get();
-    }
+  public Player updatePlayer(String playerId, Player playerDetails) {
 
-    public Player updatePlayer(String playerId, Player playerDetails) {
+    Player player = getPlayer(playerId);
+    player.setName(playerDetails.getName());
+    player.setPoints(playerDetails.getPoints());
+    player.setFouls(playerDetails.getFouls());
 
-        Player player = getPlayer(playerId);
-        player.setName(playerDetails.getName());
-        player.setPoints(playerDetails.getPoints());
-        player.setFouls(playerDetails.getFouls());
+    return playerRepository.save(player);
+  }
 
-        return playerRepository.save(player);
-    }
+  public void deletePlayer(String playerId) {
+    Player player = getPlayer(playerId);
+    playerRepository.delete(player);
+  }
 
-    public void deletePlayer(String playerId) {
-        Player player = getPlayer(playerId);
-        playerRepository.delete(player);
-    }
+  public void addPoint(String gameId, String color, String pointType) {
+    String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
+    Player player = getPlayer(playerId);
+    PointsType scoredPoint = KumiteGameManagementUtils.mapPointToPointType(pointType);
+    player.addPoint(scoredPoint);
+    playerRepository.save(player);
+    gameHelperService.updateKumiteGame(gameId, color);
+  }
 
-    public void addPoint(String gameId, String color, String pointType) {
-        String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
-        Player player = getPlayer(playerId);
-        PointsType scoredPoint = KumiteGameManagementUtils.mapPointToPointType(pointType);
-        player.addPoint(scoredPoint);
-        playerRepository.save(player);
-        gameHelperService.updateKumiteGame(gameId, color);
-    }
+  public void removePoint(String gameId, String color, String pointType) {
 
-    public void removePoint(String gameId, String color, String pointType) {
+    String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
+    Player player = getPlayer(playerId);
+    PointsType pointToRemove = KumiteGameManagementUtils.mapPointToPointType(pointType);
+    player.removePoint(pointToRemove);
+    playerRepository.save(player);
+    gameHelperService.updateKumiteGame(gameId, color);
+  }
 
-        String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
-        Player player = getPlayer(playerId);
-        PointsType pointToRemove = KumiteGameManagementUtils.mapPointToPointType(pointType);
-        player.removePoint(pointToRemove);
-        playerRepository.save(player);
-        gameHelperService.updateKumiteGame(gameId, color);
-    }
-    public void addFoul(String gameId, String color) {
+  public void addFoul(String gameId, String color) {
 
-        String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
-        Player player = getPlayer(playerId);
-        player.addFoul();
-        playerRepository.save(player);
-        gameHelperService.updateKumiteGame(gameId, color);
+    String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
+    Player player = getPlayer(playerId);
+    player.addFoul();
+    playerRepository.save(player);
+    gameHelperService.updateKumiteGame(gameId, color);
+  }
 
-    }
+  public void removeFoul(String gameId, String color) {
 
-    public void removeFoul(String gameId, String color) {
-
-        String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
-        Player player = getPlayer(playerId);
-        player.removeFoul();
-        playerRepository.save(player);
-        gameHelperService.updateKumiteGame(gameId, color);
-
-    }
+    String playerId = gameHelperService.getPlayerIdByGameAndColor(gameId, color);
+    Player player = getPlayer(playerId);
+    player.removeFoul();
+    playerRepository.save(player);
+    gameHelperService.updateKumiteGame(gameId, color);
+  }
 }

--- a/src/main/java/com/management/util/GameConfig.java
+++ b/src/main/java/com/management/util/GameConfig.java
@@ -11,14 +11,14 @@ import org.slf4j.LoggerFactory;
 
 public class GameConfig {
   private static final String CONFIG_FILE = "config.properties";
-  private static final Logger logger = LoggerFactory.getLogger(GameConfig.class);
+  private static final Logger log = LoggerFactory.getLogger(GameConfig.class);
   private final Properties properties;
 
   public GameConfig() {
     properties = new Properties();
     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE)) {
       if (inputStream == null) {
-        logger.error("Unable to find config file: {}", CONFIG_FILE);
+        log.error("Unable to find config file: {}", CONFIG_FILE);
         return;
       }
       properties.load(inputStream);
@@ -29,7 +29,7 @@ public class GameConfig {
 
   public Duration getDefaultDuration() {
     int seconds = Integer.parseInt(properties.getProperty("default.duration"));
-    logger.debug("Loaded default time from config file");
+    log.debug("Loaded default time from config file");
     return Duration.ofSeconds(seconds);
   }
 
@@ -37,7 +37,7 @@ public class GameConfig {
     String propertyValue = properties.getProperty("optional.durations");
 
     if (propertyValue == null || propertyValue.isBlank()) {
-      logger.warn("No optional durations found in the configuration. Using default duration.");
+      log.warn("No optional durations found in the configuration. Using default duration.");
       return List.of(getDefaultDuration());
     }
 
@@ -48,7 +48,7 @@ public class GameConfig {
           .map(Duration::ofSeconds)
           .toList();
     } catch (NumberFormatException e) {
-      logger.error(
+      log.error(
           "Invalid duration format in configuration: {}. Using default duration.",
           propertyValue,
           e);

--- a/src/main/java/com/management/util/GameConfig.java
+++ b/src/main/java/com/management/util/GameConfig.java
@@ -1,57 +1,58 @@
 package com.management.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GameConfig {
-    private static final String CONFIG_FILE = "config.properties";
-    private static final Logger logger = LoggerFactory.getLogger(GameConfig.class);
-    private final Properties properties;
+  private static final String CONFIG_FILE = "config.properties";
+  private static final Logger logger = LoggerFactory.getLogger(GameConfig.class);
+  private final Properties properties;
 
-    public GameConfig() {
-        properties = new Properties();
-        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE)) {
-            if (inputStream == null) {
-                logger.error("Unable to find config file: {}", CONFIG_FILE);
-                return;
-            }
-            properties.load(inputStream);
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        }
+  public GameConfig() {
+    properties = new Properties();
+    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE)) {
+      if (inputStream == null) {
+        logger.error("Unable to find config file: {}", CONFIG_FILE);
+        return;
+      }
+      properties.load(inputStream);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+  }
+
+  public Duration getDefaultDuration() {
+    int seconds = Integer.parseInt(properties.getProperty("default.duration"));
+    logger.debug("Loaded default time from config file");
+    return Duration.ofSeconds(seconds);
+  }
+
+  public List<Duration> getOptionalDurations() {
+    String propertyValue = properties.getProperty("optional.durations");
+
+    if (propertyValue == null || propertyValue.isBlank()) {
+      logger.warn("No optional durations found in the configuration. Using default duration.");
+      return List.of(getDefaultDuration());
     }
 
-    public Duration getDefaultDuration() {
-        int seconds = Integer.parseInt(properties.getProperty("default.duration"));
-        logger.debug("Loaded default time from config file");
-        return Duration.ofSeconds(seconds);
+    try {
+      return Arrays.stream(propertyValue.split(","))
+          .map(String::trim)
+          .map(Integer::parseInt)
+          .map(Duration::ofSeconds)
+          .toList();
+    } catch (NumberFormatException e) {
+      logger.error(
+          "Invalid duration format in configuration: {}. Using default duration.",
+          propertyValue,
+          e);
+      return List.of(getDefaultDuration());
     }
-
-    public List<Duration> getOptionalDurations() {
-        String propertyValue = properties.getProperty("optional.durations");
-
-        if (propertyValue == null || propertyValue.isBlank()) {
-            logger.warn("No optional durations found in the configuration. Using default duration.");
-            return List.of(getDefaultDuration());
-        }
-
-        try {
-            return Arrays.stream(propertyValue.split(","))
-                    .map(String::trim)
-                    .map(Integer::parseInt)
-                    .map(Duration::ofSeconds)
-                    .toList();
-        } catch (NumberFormatException e) {
-            logger.error("Invalid duration format in configuration: {}. Using default duration.", propertyValue, e);
-            return List.of(getDefaultDuration());
-        }
-    }
-
+  }
 }

--- a/src/main/java/com/management/util/KumiteGameManagementUtils.java
+++ b/src/main/java/com/management/util/KumiteGameManagementUtils.java
@@ -9,40 +9,46 @@ import org.slf4j.LoggerFactory;
 
 public class KumiteGameManagementUtils {
 
-    private KumiteGameManagementUtils() {
-        throw new IllegalStateException("Utility class cannot be instantiated");
-    }
-    private static final Logger logger = LoggerFactory.getLogger(KumiteGameManagementUtils.class);
-    public static PlayerColor mapPlayerColor(String color){
-        if (!(isInPlayerColor(color))){
-            logger.error("KumiteGameManagementUtils - mapPlayerColor - could not map color: {}", color);
-            throw new PlayerNotFoundException("No player associated with the color " + color + " in this game.");
-        }
-        return PlayerColor.valueOf(color.toUpperCase());
-    }
-    public static boolean isInPlayerColor(String color) {
-        try {
-            PlayerColor.valueOf(color.toUpperCase());
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-    }
+  private KumiteGameManagementUtils() {
+    throw new IllegalStateException("Utility class cannot be instantiated");
+  }
 
-    public static PointsType mapPointToPointType(String pointType) {
-        if (!(isInPointsType(pointType))){
-            logger.error("KumiteGameManagementUtils - mapPointToPointType - could not map point: {}", pointType);
-            throw new PointTypeNotFoundException("No point associated with the point " + pointType + " in points.");
-        }
-        return PointsType.valueOf(pointType.toUpperCase());
-    }
+  private static final Logger logger = LoggerFactory.getLogger(KumiteGameManagementUtils.class);
 
-    public static boolean isInPointsType(String pointType) {
-        try {
-            PointsType.valueOf(pointType.toUpperCase());
-            return true;
-        } catch (IllegalArgumentException e) {
-                return false;
-        }
+  public static PlayerColor mapPlayerColor(String color) {
+    if (!(isInPlayerColor(color))) {
+      logger.error("KumiteGameManagementUtils - mapPlayerColor - could not map color: {}", color);
+      throw new PlayerNotFoundException(
+          "No player associated with the color " + color + " in this game.");
     }
+    return PlayerColor.valueOf(color.toUpperCase());
+  }
+
+  public static boolean isInPlayerColor(String color) {
+    try {
+      PlayerColor.valueOf(color.toUpperCase());
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public static PointsType mapPointToPointType(String pointType) {
+    if (!(isInPointsType(pointType))) {
+      logger.error(
+          "KumiteGameManagementUtils - mapPointToPointType - could not map point: {}", pointType);
+      throw new PointTypeNotFoundException(
+          "No point associated with the point " + pointType + " in points.");
+    }
+    return PointsType.valueOf(pointType.toUpperCase());
+  }
+
+  public static boolean isInPointsType(String pointType) {
+    try {
+      PointsType.valueOf(pointType.toUpperCase());
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
 }

--- a/src/main/java/com/management/util/KumiteGameManagementUtils.java
+++ b/src/main/java/com/management/util/KumiteGameManagementUtils.java
@@ -13,11 +13,11 @@ public class KumiteGameManagementUtils {
     throw new IllegalStateException("Utility class cannot be instantiated");
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(KumiteGameManagementUtils.class);
+  private static final Logger log = LoggerFactory.getLogger(KumiteGameManagementUtils.class);
 
   public static PlayerColor mapPlayerColor(String color) {
     if (!(isInPlayerColor(color))) {
-      logger.error("KumiteGameManagementUtils - mapPlayerColor - could not map color: {}", color);
+      log.error("KumiteGameManagementUtils - mapPlayerColor - could not map color: {}", color);
       throw new PlayerNotFoundException(
           "No player associated with the color " + color + " in this game.");
     }
@@ -35,7 +35,7 @@ public class KumiteGameManagementUtils {
 
   public static PointsType mapPointToPointType(String pointType) {
     if (!(isInPointsType(pointType))) {
-      logger.error(
+      log.error(
           "KumiteGameManagementUtils - mapPointToPointType - could not map point: {}", pointType);
       throw new PointTypeNotFoundException(
           "No point associated with the point " + pointType + " in points.");

--- a/src/test/java/com/management/kumitegametests/ActuatorHealthIT.java
+++ b/src/test/java/com/management/kumitegametests/ActuatorHealthIT.java
@@ -1,6 +1,10 @@
 package com.management.kumitegametests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 import com.management.kumitegame.KumiteGameStarter;
+import java.time.Duration;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -16,51 +20,48 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
 @SpringBootTest(classes = KumiteGameStarter.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ActuatorHealthIT {
 
-    @Container
-    @ServiceConnection
-    static MongoDBContainer mongo = new MongoDBContainer("mongo:7");
+  @Container @ServiceConnection static MongoDBContainer mongo = new MongoDBContainer("mongo:7");
 
-    private final TestRestTemplate rest;
+  private final TestRestTemplate rest;
 
-    @Autowired
-    public ActuatorHealthIT(TestRestTemplate rest) {
-        this.rest = rest;
-    }
+  @Autowired
+  public ActuatorHealthIT(TestRestTemplate rest) {
+    this.rest = rest;
+  }
 
-    @Test
-    @Order(1)
-    void healthIsUpWhenMongoIsReachable() {
-        await().atMost(Duration.ofSeconds(20))
-                .pollInterval(Duration.ofSeconds(1))
-                .untilAsserted(() -> {
-                    ResponseEntity<String> response = rest.getForEntity("/actuator/health", String.class);
-                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-                    assertThat(response.getBody()).contains("\"status\":\"UP\"");
-                    assertThat(response.getBody()).contains("\"mongo\"");
-                });
-    }
+  @Test
+  @Order(1)
+  void healthIsUpWhenMongoIsReachable() {
+    await()
+        .atMost(Duration.ofSeconds(20))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              ResponseEntity<String> response = rest.getForEntity("/actuator/health", String.class);
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              assertThat(response.getBody()).contains("\"status\":\"UP\"");
+              assertThat(response.getBody()).contains("\"mongo\"");
+            });
+  }
 
-    @Test
-    @Order(2)
-    void healthIsDownWhenMongoIsUnreachable() {
-        mongo.stop();
+  @Test
+  @Order(2)
+  void healthIsDownWhenMongoIsUnreachable() {
+    mongo.stop();
 
-        await().atMost(Duration.ofSeconds(40))
-                .pollInterval(Duration.ofSeconds(1))
-                .untilAsserted(() -> {
-                    ResponseEntity<String> response = rest.getForEntity("/actuator/health", String.class);
-                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-                    assertThat(response.getBody()).contains("\"status\":\"DOWN\"");
-                });
-    }
+    await()
+        .atMost(Duration.ofSeconds(40))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              ResponseEntity<String> response = rest.getForEntity("/actuator/health", String.class);
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+              assertThat(response.getBody()).contains("\"status\":\"DOWN\"");
+            });
+  }
 }

--- a/src/test/java/com/management/kumitegametests/KumiteGameControllerTests.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameControllerTests.java
@@ -1,15 +1,13 @@
 package com.management.kumitegametests;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 class KumiteGameControllerTests {
 
-//    @Test
-//    void contextLoads() {
-//        assertTrue(true);
-//    }
+  //    @Test
+  //    void contextLoads() {
+  //        assertTrue(true);
+  //    }
 
 }

--- a/src/test/java/com/management/kumitegametests/KumiteGameTimerTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameTimerTest.java
@@ -1,5 +1,9 @@
 package com.management.kumitegametests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import com.management.enums.GameState;
 import com.management.enums.PlayerColor;
 import com.management.models.KumiteGame;
@@ -8,6 +12,8 @@ import com.management.models.Referee;
 import com.management.repositories.KumiteGameRepository;
 import com.management.services.KumiteGameService;
 import com.management.util.GameConfig;
+import java.time.Duration;
+import java.util.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,106 +21,96 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.time.Duration;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 class KumiteGameTimerTest {
-    @Mock
-    private KumiteGameRepository kumiteGameRepository;
+  @Mock private KumiteGameRepository kumiteGameRepository;
 
-    @Mock
-    private GameConfig gameConfig;
+  @Mock private GameConfig gameConfig;
 
-    @InjectMocks
-    private KumiteGameService kumiteGameService;
+  @InjectMocks private KumiteGameService kumiteGameService;
 
-    private KumiteGame testGame;
+  private KumiteGame testGame;
 
-    private AutoCloseable mocks = MockitoAnnotations.openMocks(this);
+  private AutoCloseable mocks = MockitoAnnotations.openMocks(this);
 
-    @BeforeEach
-    public void setUp() {
+  @BeforeEach
+  public void setUp() {
 
-        mocks = MockitoAnnotations.openMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
 
-        Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
-        playersMap.put(PlayerColor.RED, new Player("Player 1"));
-        playersMap.put(PlayerColor.BLUE, new Player("Player 2"));
-        List<Referee> refereesList = Collections.singletonList(new Referee("Referee 1"));
+    Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
+    playersMap.put(PlayerColor.RED, new Player("Player 1"));
+    playersMap.put(PlayerColor.BLUE, new Player("Player 2"));
+    List<Referee> refereesList = Collections.singletonList(new Referee("Referee 1"));
 
-        when(gameConfig.getDefaultDuration()).thenReturn(Duration.ofSeconds(120));
-        testGame = new KumiteGame(playersMap, refereesList, gameConfig.getDefaultDuration());
+    when(gameConfig.getDefaultDuration()).thenReturn(Duration.ofSeconds(120));
+    testGame = new KumiteGame(playersMap, refereesList, gameConfig.getDefaultDuration());
 
-        when(kumiteGameRepository.save(any(KumiteGame.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(kumiteGameRepository.save(any(KumiteGame.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
 
-        testGame = kumiteGameRepository.save(testGame);
-        when(kumiteGameRepository.findById(testGame.getId())).thenReturn(Optional.of(testGame));
+    testGame = kumiteGameRepository.save(testGame);
+    when(kumiteGameRepository.findById(testGame.getId())).thenReturn(Optional.of(testGame));
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
     }
+  }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        if (mocks != null) {
-            mocks.close();
-        }
-    }
+  @Test
+  void testStartGame() {
+    testGame = kumiteGameService.startGame(testGame.getId());
 
-    @Test
-    void testStartGame() {
-        testGame = kumiteGameService.startGame(testGame.getId());
+    assertNotNull(testGame.getStartTime());
+    // The clock is running by the time this value is read, so a small amount of
+    // real time has already been subtracted. Assert a tight range: exact equality
+    // only passes where the platform clock is coarse enough to round that to zero.
+    assertThat(testGame.getRemainingTime())
+        .isBetween(Duration.ofMillis(119_900), Duration.ofSeconds(120));
+    assertEquals(GameState.RUNNING, testGame.getGameState());
+  }
 
-        assertNotNull(testGame.getStartTime());
-        // The clock is running by the time this value is read, so a small amount of
-        // real time has already been subtracted. Assert a tight range: exact equality
-        // only passes where the platform clock is coarse enough to round that to zero.
-        assertThat(testGame.getRemainingTime())
-                .isBetween(Duration.ofMillis(119_900), Duration.ofSeconds(120));
-        assertEquals(GameState.RUNNING, testGame.getGameState());
-    }
+  @Test
+  void testPauseGame() {
+    testGame = kumiteGameService.startGame(testGame.getId());
+    testGame = kumiteGameService.pauseGame(testGame.getId());
 
-    @Test
-    void testPauseGame() {
-        testGame = kumiteGameService.startGame(testGame.getId());
-        testGame = kumiteGameService.pauseGame(testGame.getId());
+    assertEquals(GameState.PAUSED, testGame.getGameState());
+    assertNull(testGame.getStartTime());
+  }
 
-        assertEquals(GameState.PAUSED, testGame.getGameState());
-        assertNull(testGame.getStartTime());
-    }
+  @Test
+  void testResumeGame() {
+    testGame = kumiteGameService.startGame(testGame.getId());
+    testGame = kumiteGameService.pauseGame(testGame.getId());
+    testGame = kumiteGameService.resumeGame(testGame.getId());
 
-    @Test
-    void testResumeGame() {
-        testGame = kumiteGameService.startGame(testGame.getId());
-        testGame = kumiteGameService.pauseGame(testGame.getId());
-        testGame = kumiteGameService.resumeGame(testGame.getId());
+    assertEquals(GameState.RUNNING, testGame.getGameState());
+    assertNotNull(testGame.getStartTime());
+  }
 
-        assertEquals(GameState.RUNNING, testGame.getGameState());
-        assertNotNull(testGame.getStartTime());
-    }
+  @Test
+  void testEndGame() {
+    testGame = kumiteGameService.startGame(testGame.getId());
+    testGame = kumiteGameService.endGame(testGame.getId());
 
-    @Test
-    void testEndGame() {
-        testGame = kumiteGameService.startGame(testGame.getId());
-        testGame = kumiteGameService.endGame(testGame.getId());
+    assertEquals(GameState.FINISHED, testGame.getGameState());
+    assertEquals(Duration.ZERO, testGame.getRemainingTime());
+  }
 
-        assertEquals(GameState.FINISHED, testGame.getGameState());
-        assertEquals(Duration.ZERO, testGame.getRemainingTime());
-    }
+  @Test
+  void testResumeGameFromPaused() {
+    testGame = kumiteGameService.startGame(testGame.getId());
+    testGame = kumiteGameService.pauseGame(testGame.getId());
 
-    @Test
-    void testResumeGameFromPaused() {
-        testGame = kumiteGameService.startGame(testGame.getId());
-        testGame = kumiteGameService.pauseGame(testGame.getId());
+    Duration remainingBeforeResume = testGame.getRemainingTime();
 
-        Duration remainingBeforeResume = testGame.getRemainingTime();
+    testGame = kumiteGameService.resumeGame(testGame.getId());
 
-        testGame = kumiteGameService.resumeGame(testGame.getId());
-
-        assertEquals(GameState.RUNNING, testGame.getGameState());
-        assertNotNull(testGame.getStartTime());
-        assertEquals(remainingBeforeResume, testGame.getRemainingTime());
-    }
-
+    assertEquals(GameState.RUNNING, testGame.getGameState());
+    assertNotNull(testGame.getStartTime());
+    assertEquals(remainingBeforeResume, testGame.getRemainingTime());
+  }
 }

--- a/src/test/java/com/management/kumitegametests/RefereePersistenceIT.java
+++ b/src/test/java/com/management/kumitegametests/RefereePersistenceIT.java
@@ -1,67 +1,53 @@
 package com.management.kumitegametests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.management.enums.PlayerColor;
 import com.management.kumitegame.KumiteGameStarter;
 import com.management.models.KumiteGame;
 import com.management.models.Player;
 import com.management.models.Referee;
 import com.management.repositories.KumiteGameRepository;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
 import java.time.Duration;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(classes = KumiteGameStarter.class)
 @Testcontainers
 class RefereePersistenceIT {
 
-    @Container
-    @ServiceConnection
-    static MongoDBContainer mongoDBContainer =
-            new MongoDBContainer("mongo:7");
+  @Container @ServiceConnection
+  static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7");
 
-    @Autowired
-    private KumiteGameRepository kumiteGameRepository;
+  @Autowired private KumiteGameRepository kumiteGameRepository;
 
-    @Test
-    void shouldPersistAndReloadReferees() {
-        Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
-        playersMap.put(PlayerColor.RED, new Player("Player 1"));
-        playersMap.put(PlayerColor.BLUE, new Player("Player 2"));
+  @Test
+  void shouldPersistAndReloadReferees() {
+    Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
+    playersMap.put(PlayerColor.RED, new Player("Player 1"));
+    playersMap.put(PlayerColor.BLUE, new Player("Player 2"));
 
-        List<Referee> referees = List.of(
-                new Referee("Referee 1"),
-                new Referee("Referee 2")
-        );
+    List<Referee> referees = List.of(new Referee("Referee 1"), new Referee("Referee 2"));
 
-        KumiteGame game = new KumiteGame(
-                playersMap,
-                referees,
-                Duration.ofSeconds(120)
-        );
+    KumiteGame game = new KumiteGame(playersMap, referees, Duration.ofSeconds(120));
 
-        KumiteGame savedGame = kumiteGameRepository.save(game);
+    KumiteGame savedGame = kumiteGameRepository.save(game);
 
-        assertNotNull(savedGame.getId());
+    assertNotNull(savedGame.getId());
 
-        KumiteGame reloadedGame = kumiteGameRepository
-                .findById(savedGame.getId())
-                .orElseThrow();
+    KumiteGame reloadedGame = kumiteGameRepository.findById(savedGame.getId()).orElseThrow();
 
-        assertEquals(2, reloadedGame.getReferees().size());
-        assertEquals("Referee 1", reloadedGame.getReferees().get(0).name());
-        assertEquals("Referee 2", reloadedGame.getReferees().get(1).name());
-
-    }
+    assertEquals(2, reloadedGame.getReferees().size());
+    assertEquals("Referee 1", reloadedGame.getReferees().get(0).name());
+    assertEquals("Referee 2", reloadedGame.getReferees().get(1).name());
+  }
 }

--- a/workflow/standards/enforcement.md
+++ b/workflow/standards/enforcement.md
@@ -41,6 +41,33 @@ Never skip to step 3 on an existing codebase. Never stop at step 1 — an unenfo
 - **Style analyser** — visibility, naming, forbidden calls, file structure. Configure from a published ruleset and suppress what genuinely does not fit; do not author a ruleset from scratch. Suppressions live in one file with a reason per entry.
 - **Correctness analyser** — null dereference, ignored return values, resource leaks, equality mistakes. Its null analysis is the highest-value part; treat those findings as defects rather than style.
 
+## One job per tool
+
+**No two tools may hold authority over the same category.** Analyser suites overlap heavily by default — formatters and style analysers both police layout, style and correctness analysers both police forbidden calls — and running them on stock configuration means one defect produces two findings, in two baselines, fixable in two places.
+
+That is not extra safety. It is a maintenance cost that grows with every tool, and it trains people to skim findings rather than read them.
+
+So when adopting a tool, name the category it owns and **remove that category from every other tool**, in the other tool's ruleset rather than in a suppression file. A useful default division:
+
+| Category | Owner |
+|---|---|
+| Layout | the formatter, alone |
+| Naming, structure, forbidden calls | the style analyser |
+| Null analysis, API misuse, correctness | the correctness analyser |
+| Coverage, duplication, history | the aggregation platform, if one is used |
+
+Prefer a formatter with no options. Formatting is the category where configurability buys nothing and costs recurring argument.
+
+**Adopting an aggregation platform is a replacement decision, not an addition.** These products are built to subsume standalone style and correctness analysers, and their vendors say so. Adopting one alongside the tools it replaces is the overlap problem at its worst. Decide which stack owns the rules, and delete the other.
+
+**Check where the gate can actually run before adopting it.** A hosted analyser needs a credential, and platforms deliberately withhold credentials from builds triggered by outside contributors' pull requests. If contribution arrives that way, a hosted gate cannot see the changes that most need reviewing, and the common workaround — the trigger that does expose the credential — hands it to unreviewed code. Rule the tool out rather than working around it.
+
+## Vendor the ruleset
+
+A published ruleset referenced by name usually ships inside the analyser's own distribution, so upgrading the analyser silently changes which rules run. Where a build ratchets on a violation count, that turns a tool upgrade into an unexplained baseline movement.
+
+Copy the ruleset into the repository and reference the copy. Upgrades then arrive as a reviewable diff, and any deviation from the published standard sits in one file with the reason next to it.
+
 ## Suppression policy
 
 A suppression is a decision, so it carries a reason. Blanket file-level or project-level suppression of a rule is equivalent to deleting the rule — do that deliberately in the ruleset instead, so it is visible in one place.


### PR DESCRIPTION
Closes #58. Second issue in Epic #82.

`workflow/standards/enforcement.md` defines six quality gates. This project had the two most
expensive — unit/slice tests and integration tests — and none of the cheap ones. Every rule in
`workflow/standards/java.md` was enforced only by whoever happened to be reviewing.

Three commits, each reviewable and revertable on its own.

## 1. `764d17b` — add the tools

| Tool | Owns | Mode |
|---|---|---|
| Spotless + google-java-format | Layout | **Enforced** |
| Checkstyle (published ruleset) | Conventions | Ratchet |
| Checkstyle (`project-standards.xml`) | `java.md`'s own rules | Ratchet |
| Error Prone + NullAway | Correctness, null analysis | Report only |
| javac `-Xlint:all,-serial` | Compiler warnings | Report only |

Spotless is enforced immediately rather than ramped: after a wholesale apply there is no backlog to
burn down, so the adoption sequence does not apply. This commit reformats all 38 source files with
no behavioural change.

Both Checkstyle gates use `maxAllowedViolations` as the ratchet `enforcement.md` step 2 requires —
the build fails if the count *rises*. Error Prone has no count ratchet in javac, so it stays
report-only until its findings are cleared and NullAway can move to `ERROR`.

`config/checkstyle/project-standards.xml` mechanises `java.md` rather than adding generic linting.
Every module in it cites the rule it implements.

**It found real defects immediately:**

- The `printStackTrace` in `GameConfig` that the audit had previously found by hand.
- NullAway flagged `GameTimer` assigning `@Nullable` to `@NonNull` fields — that is the **#25**
  defect, visible before a test runs.
- Six `JavaTimeDefaultTimeZone` findings in the timer path. `testing-strategy.md` forbids dependence
  on ambient timezone, and every one is in code Epic #24 is about to touch.

## 2. `87bec5f` — rename logger fields, tighten the ratchet

All seven loggers were `private static final Logger logger`, tripping two rules at once, so 14 of
the 18 project-rule violations were the same seven declarations counted twice. Renaming to `log`
per `java.md` clears both. Baseline **18 → 4**.

This exposed a contradiction in the ruleset, fixed in the same work: `ConstantName` defaults to
`UPPER_SNAKE`, and a logger is a `static final` field, so following `java.md` would have violated
`ConstantName` permanently. `project-standards.xml` now permits `log` explicitly, with the reason
in the file.

## 3. `92ac329` — one job per tool

The stack had two overlapping authorities:

- `google_checks.xml` re-checked layout that google-java-format already guarantees.
- The `GameConfig` `printStackTrace` was reported **twice** — by our Checkstyle rule and by Error
  Prone's `CatchAndPrintStackTrace`. One defect, two findings, two baselines.

Fixed by vendoring the published ruleset and giving each tool exactly one category:

- **Vendored `google_checks.xml`** into `config/checkstyle/`. It ships inside the Checkstyle jar, so
  bumping `checkstyle.version` silently changes which rules run and moves the ratchet baseline for
  reasons unrelated to the code. Vendoring makes that a reviewable diff. This turned out to matter
  more than the Javadoc change.
- **Removed 28 layout modules.** Spotless owns layout alone. `AvoidStarImport` and `NeedBraces` were
  kept deliberately — the formatter expands neither star imports nor missing braces.
- **Removed `MissingJavadocMethod` / `MissingJavadocType`.** Javadoc is not required on every public
  member here. The *quality* checks stay, so anything written must be well formed. Writing 110
  comments was rejected as waste: #34, #40 and #60 rewrite or replace roughly half those types.
- **Turned off Error Prone's `CatchAndPrintStackTrace`.** The Checkstyle rule is kept instead: it
  catches every call rather than only those inside a catch block, and its message cites `java.md`.

Baselines after: published ruleset **131 → 21**, Error Prone **35 → 34**.

## SonarQube: evaluated and rejected

Worth recording, because it will come up again.

It is **free with unlimited lines of code** for this repo — the LOC cap applies to private projects,
and this repo is public. It was rejected on two other grounds:

1. **Overlap.** SonarSource has itself deprecated 158 Checkstyle and PMD rules as redundant with
   SonarJava. It is designed to *replace* this stack, not sit alongside it.
2. **It cannot see most PRs here.** `SONAR_TOKEN` is a repository secret, and GitHub withholds
   secrets from `pull_request` runs originating in forks. The last four merged PRs on this repo all
   came from outside contributors, so Sonar would silently skip exactly the changes most worth
   analysing.

The standard workaround is switching the trigger to `pull_request_target`, which grants secrets to
fork-authored code. This PR **restores the comment in `ci.yml` warning against precisely that**, and
extends it to say why — the warning was load-bearing, not decorative.

## Documentation

- **`CLAUDE.md`** carries a tool registry: what each tool owns, where it is configured, how to change
  it, current baselines, and why Sonar was rejected.
- **`workflow/standards/enforcement.md`** gains the transferable principles — one job per tool,
  adopting an aggregation platform is a replacement decision rather than an addition, check where a
  hosted gate can actually run before adopting it, and vendor the ruleset. No project references, so
  it transfers unchanged.

## Verification

| Check | Result |
|---|---|
| `mvn clean verify` | BUILD SUCCESS |
| Spotless | 38 files clean |
| Checkstyle published | 21 / max 21 |
| Checkstyle project rules | 4 / max 4 |
| Tests | 5 surefire + 3 failsafe |

**The gates were proven to bite**, per `enforcement.md`'s Verify section: a deliberately planted
badly-formatted `printStackTrace` was confirmed to fail the formatter gate, then — after formatting
— to fail the Checkstyle ratchet at 19 > 18, naming the new call. Then reverted.

## Known risk

**CI runs JDK 17; this was only testable on JDK 21 locally.** Error Prone required
`-XDaddTypeAnnotationsToSymbol=true` on 21 and needs javac internals exported via `.mvn/jvm.config`
on any JDK 16+. The flag should be inert on 17, but this CI run is the actual proof. If it fails
there, that is the cause.

Error Prone is pinned to **2.39.0**, not the current 2.50.0, because 2.50.0 fails to initialise
NullAway 0.12.7 (`ProvisionException`). Revisit when NullAway catches up.

## Left deliberately

The four remaining project-rule violations each belong to an issue that owns the file: the
`GameConfig` `printStackTrace` to **#30** (it cannot be fixed without deciding fail-fast behaviour,
which *is* that issue), `HideUtilityClassConstructor` to **#46**, and the two container fields to
**#88**.

The 21 published-ruleset findings and 34 Error Prone findings are likewise left to the issues that
own those files — including three with assigned contributors (#40, #45, #60). The ratchet is the
mechanism for burning them down; fixing them here would be doing eight issues' work inside a
tooling PR.
