### PR TITLE
build: align the build and CI on JDK 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: temurin
           cache: maven
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ No transition guard is currently enforced — every transition is permitted by t
 
 ## Stack
 
-- Java: build targets **17** (`<java.version>` in `pom.xml`); local JDK is 21. The pom is authoritative.
+- Java: **21** everywhere — `<java.version>` in `pom.xml`, the local JDK, and the CI toolchain. Do not let these diverge; the build carries JDK-sensitive compiler flags for Error Prone, and a divergence makes them untestable locally.
 - Spring Boot 3.2.3, Maven, embedded Tomcat
 - MongoDB 7 in Docker — `localhost:27017`, database `kumitedb`, standalone (**not** a replica set, so multi-document transactions are unavailable)
 - Tooling: IntelliJ IDEA, Postman, MongoDB Compass
@@ -107,7 +107,7 @@ Three engines, three non-overlapping jobs. All run inside `mvn verify`; gate ord
 | **Spotless** + google-java-format | **Layout** — indentation, wrapping, import order, whitespace | `pom.xml` → `spotless-maven-plugin` | **Enforced.** Build fails; `mvn spotless:apply` fixes | 0 |
 | **Checkstyle** (published) | **Conventions** — naming, structure, braces, star imports | `config/checkstyle/google-checks-vendored.xml` | Ratchet | **21** |
 | **Checkstyle** (project) | **`java.md`'s own rules** — logger naming, `printStackTrace`, `Optional` misuse | `config/checkstyle/project-standards.xml` | Ratchet | **4** |
-| **Error Prone + NullAway** | **Correctness** — null analysis, API misuse, time/locale bugs | `pom.xml` → `maven-compiler-plugin` `compilerArgs` + `annotationProcessorPaths` | Report only | **34** (19 NullAway) |
+| **Error Prone + NullAway** | **Correctness** — null analysis, API misuse, time/locale bugs | `pom.xml` → `maven-compiler-plugin` `compilerArgs` + `annotationProcessorPaths` | Report only | **42** — 34 main (19 NullAway) + 8 test |
 | **javac** | Compiler warnings | `pom.xml` → `-Xlint:all,-serial` | Report only | 0 |
 
 ```bash
@@ -123,12 +123,12 @@ mvn verify            # everything
 - **Correctness** — Error Prone checks are toggled with `-Xep:CheckName:OFF|WARN|ERROR` in the compiler args.
 - **Suppressions** — `config/checkstyle/suppressions.xml`, one entry per reason. A suppression with no reason gets rejected in review.
 
-**The ratchet.** `maxAllowedViolations` is set to the current baseline, so the build fails if the count *rises*. Lower it as findings are fixed; it never goes up. Error Prone has no count ratchet in javac, so it stays report-only until the 34 are cleared and NullAway can move to `ERROR`.
+**The ratchet.** `maxAllowedViolations` is set to the current baseline, so the build fails if the count *rises*. Lower it as findings are fixed; it never goes up. Error Prone has no count ratchet in javac, so it stays report-only until its findings are cleared and NullAway can move to `ERROR`. Note its count depends on the command: `mvn compile` sees main sources only, `mvn verify` also compiles tests.
 
 **Deliberately not used: SonarQube.** It would duplicate most of the above — SonarSource has itself deprecated 158 Checkstyle/PMD rules as redundant with SonarJava. More decisively, its value here would be the PR gate, and GitHub withholds secrets from `pull_request` runs originating in forks. Most PRs on this repo come from forks, so Sonar would silently skip them. The usual workaround is `pull_request_target`, which hands secrets to fork-authored code — see the warning in `.github/workflows/ci.yml`. Revisit only if contribution stops coming through forks.
 
 - Main class: `com.management.kumitegame.KumiteGameStarter` (component scan covers `com.management`)
-- Spring Boot 3.2.3, Java 17 (pinned via `<java.version>` in `pom.xml`)
+- Spring Boot 3.2.3, Java 21 (pinned via `<java.version>` in `pom.xml`; CI provisions the same)
 - Windows dev setup: see `karate-app-dev-setup-windows.pdf` in the repo root.
 
 ## MCP Tooling

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <description>Karate Championship Management App</description>
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <testcontainers.version>1.21.4</testcontainers.version>
     <spotless.version>2.44.5</spotless.version>
     <google-java-format.version>1.27.0</google-java-format.version>


### PR DESCRIPTION
Closes #97.

## The problem

The build ran on a different JDK depending on who ran it — JDK 21 locally, temurin 17 in CI. The
language level was 17 in both, so the *output* was consistent, but the compiler producing it was
not.

`CLAUDE.md` recorded this as deliberate: *"build targets 17; local JDK is 21. The pom is
authoritative."* That line was the smell written down.

## Why it mattered, concretely

This is not theoretical. While adding Error Prone in #58, the compiler required
`-XDaddTypeAnnotationsToSymbol=true` — **a flag needed only on JDK 21**. Whether it was inert on
JDK 17 could not be determined locally, because no JDK 17 was present. That change shipped with a
documented "known risk" and the CI run was the only available proof.

It passed. But the correct number of build flags whose behaviour depends on an untestable JDK is
zero, and the analysers added in #58 are exactly the kind of build change that keeps raising this
question.

Targeting 17 also bought nothing here: nobody builds on it by choice, there is no deployment target
requiring it, and Spring Boot 3.2.3 supports 21 fully.

## Changes

| File | Change |
|---|---|
| `pom.xml` | `<java.version>` 17 → 21 |
| `.github/workflows/ci.yml` | toolchain 17 → 21 |
| `CLAUDE.md` | Stack section no longer describes a divergence; states 21 everywhere and why they must not drift apart |

7 insertions, 7 deletions.

## Consequence, accepted knowingly

**Contributors will need JDK 21.** Most contribution to this repository arrives as pull requests
from forks, so this does raise the bar for anyone not already set up. Accepted: 21 is LTS and widely
available, several fork contributions have already merged, and the cost of this change only grows as
more code lands.

## Verification

| Check | Result |
|---|---|
| `maven.compiler.release` | resolves to **21** |
| `mvn clean verify` | BUILD SUCCESS |
| Spotless | 38 files clean |
| Checkstyle published | 21 / max 21 |
| Checkstyle project rules | 4 / max 4 |
| Tests | 5 surefire + 3 failsafe |
| javac warnings | 0 |

## One correction included

The tool registry in `CLAUDE.md` recorded the Error Prone baseline as **34**. That number was
measured with `mvn compile`, which compiles main sources only; `mvn verify` also compiles tests and
reports **42**.

Main-only is still exactly 34 on Java 21, so this is a **measurement correction, not a regression**
from the JDK change — verified by re-running `mvn compile` after the bump and comparing per-check
counts, which are identical. Error Prone is report-only with no ratchet, so nothing was ever gated
on the wrong number. The registry now records 42 (34 main + 8 test) and notes that the count depends
on which command is run.

## Not in scope

No production code changed. This is deliberately **not** folded into Epic #89 (Spring Boot 4.1) —
that is a large piece of work, this is a two-line change removing a live source of confusion today.
Spring Boot 4 requires Java 17 or later, so landing 21 now is forward-compatible with it.

The level is not raised past 21: Spring Boot 3.2.3 predates later LTS releases and does not claim
support for them. Revisit as part of #89.
