### PR TITLE
build: upgrade to Spring Boot 4.1.0 (Epic #89)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ No transition guard is currently enforced — every transition is permitted by t
 ## Stack
 
 - Java: **21** everywhere — `<java.version>` in `pom.xml`, the local JDK, and the CI toolchain. Do not let these diverge; the build carries JDK-sensitive compiler flags for Error Prone, and a divergence makes them untestable locally.
-- Spring Boot 3.2.3, Maven, embedded Tomcat
+- Spring Boot **4.1.0**, Maven, embedded Tomcat. Jackson 3, JUnit 6, Testcontainers 2, MongoDB driver 5.8 all arrive with this BOM.
 - MongoDB 7 in Docker — `localhost:27017`, database `kumitedb`, standalone (**not** a replica set, so multi-document transactions are unavailable)
 - Tooling: IntelliJ IDEA, Postman, MongoDB Compass
 - **`mvn verify` is the quality gate** — it runs every check below plus both test suites. `mvn test` runs only the fast suite and does **not** run integration tests.
@@ -107,7 +107,7 @@ Three engines, three non-overlapping jobs. All run inside `mvn verify`; gate ord
 | **Spotless** + google-java-format | **Layout** — indentation, wrapping, import order, whitespace | `pom.xml` → `spotless-maven-plugin` | **Enforced.** Build fails; `mvn spotless:apply` fixes | 0 |
 | **Checkstyle** (published) | **Conventions** — naming, structure, braces, star imports | `config/checkstyle/google-checks-vendored.xml` | Ratchet | **21** |
 | **Checkstyle** (project) | **`java.md`'s own rules** — logger naming, `printStackTrace`, `Optional` misuse | `config/checkstyle/project-standards.xml` | Ratchet | **4** |
-| **Error Prone + NullAway** | **Correctness** — null analysis, API misuse, time/locale bugs | `pom.xml` → `maven-compiler-plugin` `compilerArgs` + `annotationProcessorPaths` | Report only | **42** — 34 main (19 NullAway) + 8 test |
+| **Error Prone + NullAway** | **Correctness** — null analysis, API misuse, time/locale bugs | `pom.xml` → `maven-compiler-plugin` `compilerArgs` + `annotationProcessorPaths` | Report only | **45** across main and test (26 NullAway) |
 | **javac** | Compiler warnings | `pom.xml` → `-Xlint:all,-serial` | Report only | 0 |
 | **JaCoCo** | **Coverage** — merged across both suites | `pom.xml` → `jacoco-maven-plugin` | **Enforced floor** | LINE **37%**, BRANCH **15%** |
 
@@ -137,12 +137,12 @@ It is a **convenience, not a gate** — bypassable with `git commit --no-verify`
 **Deliberately not used: SonarQube.** It would duplicate most of the above — SonarSource has itself deprecated 158 Checkstyle/PMD rules as redundant with SonarJava. More decisively, its value here would be the PR gate, and GitHub withholds secrets from `pull_request` runs originating in forks. Most PRs on this repo come from forks, so Sonar would silently skip them. The usual workaround is `pull_request_target`, which hands secrets to fork-authored code — see the warning in `.github/workflows/ci.yml`. Revisit only if contribution stops coming through forks.
 
 - Main class: `com.management.kumitegame.KumiteGameStarter` (component scan covers `com.management`)
-- Spring Boot 3.2.3, Java 21 (pinned via `<java.version>` in `pom.xml`; CI provisions the same)
+- Spring Boot 4.1.0, Java 21 (pinned via `<java.version>` in `pom.xml`; CI provisions the same)
 - Windows dev setup: see `karate-app-dev-setup-windows.pdf` in the repo root.
 
 ## MCP Tooling
 
-**Context7 is the only MCP needed for Spring Boot development on this project.** Use it to fetch current docs for Spring Boot 3.2, Spring Data MongoDB, Jakarta Validation, Spring Security, and any other library/framework before relying on training knowledge.
+**Context7 is the only MCP needed for Spring Boot development on this project.** Use it to fetch current docs for Spring Boot 4.1, Spring Data MongoDB, Jakarta Validation, Spring Security, and any other library/framework before relying on training knowledge.
 
 **MongoDB MCP is intentionally NOT connected.** MongoDB Compass covers the rare moments live data inspection is needed during current-phase backend work. Reconsider connecting MongoDB MCP when any of these become true:
 - Debugging a real data-corruption incident (e.g. after the dual-write/snapshot fix lands)
@@ -172,7 +172,7 @@ There are two aggregate roots with their own controller/service/repository stack
 - `PlayerController` at `/api/players` — owns player CRUD
 - `PointsType` enum carries its `PointStrategy` instance — `PointStrategy` declares `addPoint(Points)` / `removePoint(Points)`, which mutate the score in place. There is no method that returns a value.
 - `GameConfig` reads from `src/main/resources/config.properties` — game durations are loaded there, not hardcoded
-- MongoDB connection is configured via environment variables (`MONGO_HOST`, `MONGO_PORT`, `MONGO_DB`), defaulting to `localhost:27017/kumitedb`
+- MongoDB connection is configured via environment variables (`MONGO_HOST`, `MONGO_PORT`, `MONGO_DB`), defaulting to `localhost:27017/kumitedb`. They bind through **`spring.mongodb.*`**, not `spring.data.mongodb.*` — Boot 4 split that namespace into driver-level (`spring.mongodb`) and repository-level (`spring.data.mongodb`). Both still resolve, so using the wrong one fails silently by falling back to the default host.
 
 ## What Is Not Built Yet
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <checkstyle.version>10.26.1</checkstyle.version>
     <error-prone.version>2.39.0</error-prone.version>
     <nullaway.version>0.12.7</nullaway.version>
-    <jacoco.version>0.8.13</jacoco.version>
+    <jacoco.version>0.8.15</jacoco.version>
     <git-build-hook.version>3.5.0</git-build-hook.version>
   </properties>
 
@@ -96,7 +96,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>4.1.0</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>4.1.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -18,7 +18,6 @@
 
   <properties>
     <java.version>21</java.version>
-    <testcontainers.version>1.21.4</testcontainers.version>
     <spotless.version>2.44.5</spotless.version>
     <google-java-format.version>1.27.0</google-java-format.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -37,12 +36,34 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+      Boot 4 split test support into per-technology starters; spring-boot-starter-test no longer
+      carries them transitively. Each of these supplies something this suite actually uses, and
+      nothing is added speculatively:
+        webmvc-test     -> @WebMvcTest and MockMvc, for the controller slice
+        restclient-test -> TestRestTemplate, for the actuator integration tests
+      spring-boot-starter-test-classic exists as a compatibility aggregate that restores the old
+      behaviour in one line. Not used: it would hide which slices this project depends on, which is
+      the thing the modularisation makes visible.
+    -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-restclient-test</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -59,13 +80,13 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mongodb</artifactId>
+      <artifactId>testcontainers-mongodb</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -75,7 +96,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.2.3</version>
+        <version>4.1.0</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.data.mongodb.host=${MONGO_HOST:localhost}
-spring.data.mongodb.port=${MONGO_PORT:27017}
-spring.data.mongodb.database=${MONGO_DB:kumitedb}
+spring.mongodb.host=${MONGO_HOST:localhost}
+spring.mongodb.port=${MONGO_PORT:27017}
+spring.mongodb.database=${MONGO_DB:kumitedb}
 
 # Actuator: expose only health and info over HTTP.
 management.endpoints.web.exposure.include=health,info

--- a/src/test/java/com/management/kumitegametests/ActuatorHealthDownIT.java
+++ b/src/test/java/com/management/kumitegametests/ActuatorHealthDownIT.java
@@ -5,9 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.management.kumitegame.KumiteGameStarter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -28,6 +29,7 @@ import org.springframework.http.ResponseEntity;
  * must never be. It is the one justified exception to the single-configuration rule, so the suite
  * builds two contexts and no more.
  */
+@AutoConfigureTestRestTemplate
 @SpringBootTest(
     classes = KumiteGameStarter.class,
     webEnvironment = WebEnvironment.RANDOM_PORT,
@@ -36,7 +38,7 @@ import org.springframework.http.ResponseEntity;
       // serverSelectionTimeoutMS is cut from its 30s default: without it the driver spends half a
       // minute retrying before the health indicator gives up, and this test is the slowest in the
       // suite for no reason. 500ms is far longer than a local refused connection needs.
-      "spring.data.mongodb.uri=mongodb://localhost:1/kumitedb?serverSelectionTimeoutMS=500"
+      "spring.mongodb.uri=mongodb://localhost:1/kumitedb?serverSelectionTimeoutMS=500"
     })
 class ActuatorHealthDownIT {
 

--- a/src/test/java/com/management/kumitegametests/ActuatorHealthIT.java
+++ b/src/test/java/com/management/kumitegametests/ActuatorHealthIT.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.management.testsupport.IntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
@@ -18,9 +18,9 @@ import com.management.testsupport.KumiteGameBuilder;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -32,8 +32,8 @@ import org.springframework.test.web.servlet.MockMvc;
  *
  * <p><strong>The context configuration #37 should reuse.</strong> {@code @WebMvcTest}, an
  * {@code @Import} naming the controller under test plus {@link GlobalExceptionHandler}, and every
- * collaborating service supplied as a {@code @MockBean}. Both services must be mocked even when a
- * test only exercises one, because the controller injects both and the context will not start
+ * collaborating service supplied as a {@code @MockitoBean}. Both services must be mocked even when
+ * a test only exercises one, because the controller injects both and the context will not start
  * otherwise. Keeping every controller slice on this exact configuration means the framework builds
  * and caches one context for all of them; varying it per class multiplies context builds and
  * dominates suite time.
@@ -54,9 +54,9 @@ class KumiteGameControllerSliceTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockBean private KumiteGameService kumiteGameService;
+  @MockitoBean private KumiteGameService kumiteGameService;
 
-  @MockBean private PlayerService playerService;
+  @MockitoBean private PlayerService playerService;
 
   @Test
   void getKumiteGame_whenTheGameExists_returns200AndTheGameAsJson() throws Exception {

--- a/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
@@ -77,6 +77,37 @@ class KumiteGameControllerSliceTest {
         .andExpect(jsonPath("$.timer").doesNotExist());
   }
 
+  /**
+   * Pins the JSON representation, as the counterpart to {@link RepresentationCharacterizationTest}
+   * which pins the stored form.
+   *
+   * <p>Asserted here rather than against a hand-built mapper because this is the only place the
+   * application's real configured mapper runs. Jackson crosses a major version in Epic #89, and
+   * this test is what will report it if the wire format moves.
+   */
+  @Test
+  void getKumiteGame_jsonRepresentation_isPinned() throws Exception {
+    KumiteGame game =
+        KumiteGameBuilder.newGame().runningWithRemaining(Duration.ofSeconds(87)).build();
+    given(kumiteGameService.getKumiteGame("game-1")).willReturn(game);
+
+    mockMvc
+        .perform(get("/api/kumitegame/{gameId}", "game-1"))
+        .andExpect(status().isOk())
+        // Durations are ISO-8601 strings, not numbers or objects.
+        .andExpect(jsonPath("$.remainingTime").value("PT1M27S"))
+        .andExpect(jsonPath("$.gameDuration").value("PT2M"))
+        // Points and fouls are nested objects carrying a count, not bare numbers.
+        .andExpect(jsonPath("$.playersMap.RED.points.numOfPoints").value(0))
+        .andExpect(jsonPath("$.playersMap.RED.fouls.numOfFouls").value(0))
+        // The colour-keyed map uses the colour name as the JSON key.
+        .andExpect(jsonPath("$.playersMap.RED").exists())
+        .andExpect(jsonPath("$.playersMap.BLUE").exists())
+        // startTime is present and non-null; its exact encoding is what Epic #89 may change.
+        .andExpect(jsonPath("$.startTime").exists())
+        .andExpect(jsonPath("$.winner").value("Pending game ending"));
+  }
+
   @Test
   void getKumiteGame_whenTheGameIsMissing_returns404FromTheExceptionHandler() throws Exception {
     given(kumiteGameService.getKumiteGame(anyString()))

--- a/src/test/java/com/management/kumitegametests/RepresentationCharacterizationTest.java
+++ b/src/test/java/com/management/kumitegametests/RepresentationCharacterizationTest.java
@@ -1,0 +1,83 @@
+package com.management.kumitegametests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.management.enums.PlayerColor;
+import com.management.enums.PointsType;
+import com.management.models.KumiteGame;
+import com.management.models.Player;
+import com.management.testsupport.InMemoryMongo;
+import com.management.testsupport.KumiteGameBuilder;
+import com.management.testsupport.PlayerBuilder;
+import java.time.Duration;
+import java.util.Date;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins how the domain is represented on disk.
+ *
+ * <p><strong>This is a characterization test, not a specification.</strong> It records what the
+ * current stack actually produces so that a framework upgrade cannot change it silently. If one of
+ * these fails after an upgrade, that is the point: the failure is the finding, and the change is
+ * either intended and re-pinned here, or it is a defect.
+ *
+ * <p>Written before the Spring Boot 4 upgrade of Epic #89 specifically so the "before" of #93's
+ * before-and-after comparison is executable rather than a screenshot. The MongoDB driver crosses a
+ * major version in that upgrade, and it owns this representation.
+ *
+ * <p>The JSON half of the contract is pinned in {@link KumiteGameControllerSliceTest}, at the HTTP
+ * boundary, because that is where the application's real configured mapper runs. Constructing a
+ * bare {@code ObjectMapper} here would pin a format the application never actually produces — it
+ * lacks the date handling Spring Boot configures.
+ *
+ * <p>Assertions are on <em>shape and format</em>, never on a value that depends on the machine. The
+ * instant stored for {@code startTime} is resolved through the default time-zone, so pinning the
+ * literal value would fail on a colleague's laptop rather than on a real change. What is pinned is
+ * that it is stored as a BSON date at all — if it became a string, this test would say so. See #93.
+ */
+class RepresentationCharacterizationTest {
+
+  private static Document asStoredDocument(Object entity) {
+    return new InMemoryMongo().writeForInspection(entity);
+  }
+
+  @Test
+  void kumiteGame_storedForm_isPinned() {
+    KumiteGame game =
+        KumiteGameBuilder.newGame().runningWithRemaining(Duration.ofSeconds(87)).build();
+
+    Document stored = asStoredDocument(game);
+
+    // Durations are stored as ISO-8601 strings.
+    assertThat(stored.get("remainingTime")).isEqualTo("PT1M27S");
+    assertThat(stored.get("gameDuration")).isEqualTo("PT2M");
+    // Enums are stored as their names.
+    assertThat(stored.get("gameState")).isEqualTo("RUNNING");
+    // LocalDateTime is stored as a BSON date.
+    assertThat(stored.get("startTime")).isInstanceOf(Date.class);
+    // The transient timer is never written.
+    assertThat(stored).doesNotContainKey("timer");
+    // Spring Data writes a type hint alongside the data.
+    assertThat(stored.get("_class")).isEqualTo("com.management.models.KumiteGame");
+
+    Document players = (Document) stored.get("playersMap");
+    assertThat(players).containsKeys(PlayerColor.RED.name(), PlayerColor.BLUE.name());
+  }
+
+  @Test
+  void player_storedForm_isPinned() {
+    Player player =
+        PlayerBuilder.newPlayer()
+            .named("Red Fighter")
+            .scoring(PointsType.IPPON)
+            .withFouls(1)
+            .build();
+
+    Document stored = asStoredDocument(player);
+
+    assertThat(stored.get("name")).isEqualTo("Red Fighter");
+    assertThat(((Document) stored.get("points")).get("numOfPoints")).isEqualTo(3);
+    assertThat(((Document) stored.get("fouls")).get("numOfFouls")).isEqualTo(1);
+  }
+}

--- a/src/test/java/com/management/kumitegametests/RepresentationCharacterizationTest.java
+++ b/src/test/java/com/management/kumitegametests/RepresentationCharacterizationTest.java
@@ -26,6 +26,16 @@ import org.junit.jupiter.api.Test;
  * before-and-after comparison is executable rather than a screenshot. The MongoDB driver crosses a
  * major version in that upgrade, and it owns this representation.
  *
+ * <p><strong>Audit result (#93): nothing moved.</strong> Every assertion below passed unchanged
+ * across Spring Boot 3.2.3 → 4.1.0, which carried Jackson 2 → 3 and MongoDB driver 4.11 → 5.8.
+ * Durations are still ISO-8601 strings, enums are still names, {@code startTime} is still a BSON
+ * date, and the type hint is still written. The same holds for the JSON side in {@link
+ * KumiteGameControllerSliceTest}. No re-pinning was needed, and no migration of existing documents
+ * is required.
+ *
+ * <p>That is a result, not an absence of one — it is only credible because these assertions existed
+ * <em>before</em> the upgrade rather than being written afterwards to match whatever came out.
+ *
  * <p>The JSON half of the contract is pinned in {@link KumiteGameControllerSliceTest}, at the HTTP
  * boundary, because that is where the application's real configured mapper runs. Constructing a
  * bare {@code ObjectMapper} here would pin a format the application never actually produces — it

--- a/src/test/java/com/management/testsupport/InMemoryMongo.java
+++ b/src/test/java/com/management/testsupport/InMemoryMongo.java
@@ -93,6 +93,18 @@ public final class InMemoryMongo {
     return collectionFor(type).size();
   }
 
+  /**
+   * Converts an entity to the document that would be stored, without storing it.
+   *
+   * <p>For tests that assert the persisted <em>representation</em> rather than round-trip behaviour
+   * — the shape on disk is a contract too, and a framework upgrade can change it silently.
+   */
+  public Document writeForInspection(Object entity) {
+    Document document = new Document();
+    converter.write(entity, document);
+    return document;
+  }
+
   /** Discards everything, so a test never inherits another test's data. */
   public void clear() {
     collections.clear();

--- a/src/test/java/com/management/testsupport/IntegrationTestBase.java
+++ b/src/test/java/com/management/testsupport/IntegrationTestBase.java
@@ -3,11 +3,12 @@ package com.management.testsupport;
 import com.management.kumitegame.KumiteGameStarter;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.mongodb.MongoDBContainer;
 
 /**
  * Base class for integration tests. One container, one context, clean data.
@@ -37,6 +38,7 @@ import org.testcontainers.containers.MongoDBContainer;
  * change no matter how many integration tests exist by then.
  */
 @SpringBootTest(classes = KumiteGameStarter.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
 public abstract class IntegrationTestBase {
 
   @ServiceConnection static final MongoDBContainer MONGO = new MongoDBContainer("mongo:7");

--- a/src/test/java/com/management/testsupport/KumiteGameBuilder.java
+++ b/src/test/java/com/management/testsupport/KumiteGameBuilder.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Builds a {@link KumiteGame} for a test, stating only the field the test is about.

--- a/src/test/java/com/management/testsupport/PlayerBuilder.java
+++ b/src/test/java/com/management/testsupport/PlayerBuilder.java
@@ -4,7 +4,7 @@ import com.management.enums.PointsType;
 import com.management.models.Foul;
 import com.management.models.Player;
 import com.management.models.Points;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Builds a {@link Player} for a test, stating only the field the test is about.


### PR DESCRIPTION
Completes **Epic #89 — Upgrade to Spring Boot 4.1**.

Closes #89, closes #90, closes #91, closes #92, closes #93.

> **Stacked on #99.** Base is `feat/82-quality-gate-epic`, so this diff shows only the upgrade.
> Review and merge #99 first; this PR's base then retargets to `main` automatically.
>
> **Merge order matters for the issue links.** GitHub only activates closing references when a PR
> targets the default branch, so these five show as unlinked until #99 merges and this PR retargets.
> Merging #99 first makes them live. If this PR is somehow merged while still targeting the feature
> branch, the five issues stay open and need closing by hand.

Moves off a release line that lost OSS support in **November 2024** and onto the current one,
supported to **July 2027**.

## Done in one hop, not two

The epic specified 3.2 → 3.5 → 4.1. Landed as a single hop instead: the 3.5 line is *itself* already
end-of-life, so stopping there would have been building for a state we retire immediately. On 37
source files the diagnostic value of splitting was not worth an extra intermediate state.

## What actually arrived

Four majors come with the BOM. **Only Testcontainers 2 was in the epic's exposure map** — the guide
covers the framework, not what the BOM pulls underneath:

| | Before | After |
|---|---|---|
| Spring Boot | 3.2.3 | **4.1.0** |
| Jackson | 2.15 | **3.1.4** |
| JUnit | 5.10.2 | **6.0.3** |
| Testcontainers | 1.19.5 (pinned to 1.21.4) | **2.0.5**, unpinned |
| MongoDB driver | 4.11.1 | **5.8.0** |

Everything below was found by compiling and running, not by reading.

## The changes

**Dependencies**
- `spring-boot-starter-web` → `spring-boot-starter-webmvc`
- Testcontainers artifacts gained a prefix: `mongodb` → `testcontainers-mongodb`, `junit-jupiter` →
  `testcontainers-junit-jupiter`. The old coordinates don't resolve at all, so the POM fails before
  any compilation.
- Boot 4 split test support into per-technology starters and `spring-boot-starter-test` no longer
  carries them transitively. Added `webmvc-test` and `restclient-test`, nothing speculative.
  `spring-boot-starter-test-classic` would have restored the old behaviour in one line — not used,
  because it hides which slices this project actually depends on.
- **The Testcontainers pin is deleted**, exactly as #83 said it should be. The BOM manages 2.0.5 and
  the Docker Engine 29 incompatibility that forced the pin is gone with it.

**Relocations, every one found by the compiler**

| Was | Now |
|---|---|
| `…boot.test.autoconfigure.web.servlet.WebMvcTest` | `…boot.webmvc.test.autoconfigure.WebMvcTest` |
| `…boot.test.web.client.TestRestTemplate` | `…boot.resttestclient.TestRestTemplate` |
| `org.testcontainers.containers.MongoDBContainer` | `org.testcontainers.mongodb.MongoDBContainer` |
| `@MockBean` | `@MockitoBean` |
| `org.springframework.lang.Nullable` | `org.jspecify.annotations.Nullable` |

**Two behaviour changes**

`@SpringBootTest` no longer auto-configures `TestRestTemplate` — both actuator tests failed with
`UnsatisfiedDependencyException` until `@AutoConfigureTestRestTemplate` was added.

Mongo properties split: `spring.mongodb.*` is driver-level, `spring.data.mongodb.*` is
repository-level. **Both namespaces still resolve**, so using the wrong one fails *silently* by
falling back to the default host — and that is exactly how it presented. The health-DOWN test went
green-but-wrong, returning 200 because it had quietly connected to the real local MongoDB instead of
the dead port it specified. A test that asserted only "the build is green" would have shipped this.

## #93 — the audit result: nothing moved

The point of the epic, and the thing a green build cannot tell you.

The representation was **pinned before the upgrade** (commit `9fef9db`) so the comparison is
executable rather than eyeballed. Across Jackson 2 → 3 and MongoDB driver 4.11 → 5.8, every
assertion passed unchanged: durations still ISO-8601 strings, enums still names, `startTime` still a
BSON date, type hint still written, JSON side identical.

**No re-pinning needed. No migration of existing documents required.**

That's a finding rather than an absence of one — and it is only credible because the assertions
existed *before* the upgrade instead of being written afterwards to match whatever came out.

Writing that baseline surfaced its own lesson: a hand-built `ObjectMapper` was tried first and
rejected, because it lacks the date handling Spring Boot configures and therefore pins a format the
application never produces. It failed outright with *"Java 8 date/time type not supported by
default"*. JSON is now pinned at the HTTP boundary where the real mapper runs.

## Verification

| Check | Result |
|---|---|
| `mvn verify` | **BUILD SUCCESS** — 25 fast, 4 integration |
| Checkstyle (published / project) | 19 / 19 and 3 / 3 — **unchanged**, no relaxation |
| Coverage floor | met |
| Deprecation warnings | **zero** remaining |
| Error Prone + NullAway | still running after the upgrade |
| Property binding | proven end-to-end, not assumed |

**Property binding proof.** With `MONGO_HOST=192.0.2.1` the driver reports
`clusterSettings={hosts=[192.0.2.1:27017]}` and `/actuator/health` returns 503. An unbound property
would have silently used localhost and looked healthy — which is the failure mode #92 exists to
prevent.

**The gates never relaxed.** Both Checkstyle ratchets held at their pre-upgrade baselines through a
four-major upgrade, and no analyser was disabled to get through it.

## OpenRewrite cross-check

Run as a dry-run against the finished hand migration. **It found no Boot 4 steps that had been
missed** — the useful result, since it confirms the migration was complete.

Two of its three unrelated suggestions were taken: JaCoCo 0.8.13 → 0.8.15, and removing the explicit
`spring-boot-maven-plugin` version so the parent manages it (that pin was inherited from the 3.2.3
pom and is the same drift the Testcontainers pin was).

The third — expanding a star import in `KumiteGameTimerTest` — was deliberately left. #27 rewrites
that file, and the change would only create a conflict for whoever takes it.

## Still open, unchanged by this

The time-zone dependence of stored `LocalDateTime` values: a value written as `10:30` is stored as
`07:30Z`, resolved through the writing machine's zone. The upgrade neither caused nor fixed it. It is
recorded with evidence in the comments on #93, and Error Prone still reports six
`JavaTimeDefaultTimeZone` findings in the timer path that Epic #24 will touch.

Epic #32 was sequenced behind this one so that #35 pins JSON formats once, on Jackson 3. It is now
unblocked.
