### PR TITLE
Request validation at the boundary (epic #38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ Settled in Epic #32. Persistence types do not cross the HTTP boundary in either 
 
 | Failure | Status | Exception | Detail |
 |---|---|---|---|
+| Request fails Bean Validation | 400 | `MethodArgumentNotValidException` (framework) | generic, plus an `errors` extension property mapping each failing field path to its message |
 | Not a colour (`color=purple`) | 400 | `InvalidPlayerColorException` | the message |
 | Not a point type | 400 | `PointTypeNotFoundException` | the message |
 | A request this app validated and rejected | 400 | `InvalidGameRequestException` | the message |
@@ -211,6 +212,8 @@ Settled in Epic #32. Persistence types do not cross the HTTP boundary in either 
 | Anything else | 500 | catch-all | **generic**, message logged |
 
 The two colour failures are deliberately different types: *not a colour* is the caller's mistake (400), *a colour this match does not have* is a missing resource (404).
+
+**Requests are validated at the boundary.** The request DTOs are records carrying Jakarta Bean Validation constraints, triggered by `@Valid` on the `@RequestBody` parameters; `spring-boot-starter-validation` supplies the engine. `gameDuration` is an `Integer` (seconds) — non-numeric input dies at binding as a 400, never as a hand-parse failure. What constraints cannot see — the one-RED-one-BLUE rule — stays domain validation in `KumiteGameService`.
 
 **Only messages this project wrote are returned.** `InvalidGameRequestException` marks validation whose wording is meant for the caller, so its detail is echoed. A bare `IllegalArgumentException` can come from anywhere beneath the controller — Spring Data's *"The given id must not be null"*, an enum conversion failing on a legacy document — so it still answers 400 as #36 requires, but with a fixed detail and the real message in the log. Echoing it blamed the caller for a server fault and leaked internal text through the same handler that the catch-all is careful not to.
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
       <artifactId>spring-boot-starter-webmvc</artifactId>
     </dependency>
 
+    <!-- Not transitive through the web starter since Boot 2.3; without it, constraint
+         annotations are inert and @Valid silently validates nothing. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/management/controllers/KumiteGameController.java
+++ b/src/main/java/com/management/controllers/KumiteGameController.java
@@ -5,6 +5,7 @@ import com.management.dto.KumiteGameResponse;
 import com.management.mappers.KumiteGameMapper;
 import com.management.services.KumiteGameService;
 import com.management.services.PlayerService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class KumiteGameController {
 
   @PostMapping
   public ResponseEntity<KumiteGameResponse> createKumiteGame(
-      @RequestBody KumiteGameRequestDTO gameDetails) {
+      @Valid @RequestBody KumiteGameRequestDTO gameDetails) {
     KumiteGameResponse created =
         KumiteGameMapper.toResponse(kumiteGameService.createKumiteGame(gameDetails));
     return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/management/controllers/PlayerController.java
+++ b/src/main/java/com/management/controllers/PlayerController.java
@@ -4,6 +4,7 @@ import com.management.dto.PlayerRequestDTO;
 import com.management.dto.PlayerResponse;
 import com.management.mappers.PlayerMapper;
 import com.management.services.PlayerService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +17,8 @@ public class PlayerController {
   @Autowired private PlayerService playerService;
 
   @PostMapping
-  public ResponseEntity<PlayerResponse> createPlayer(@RequestBody PlayerRequestDTO newPlayer) {
+  public ResponseEntity<PlayerResponse> createPlayer(
+      @Valid @RequestBody PlayerRequestDTO newPlayer) {
     PlayerResponse created = PlayerMapper.toResponse(playerService.createPlayer(newPlayer));
     return ResponseEntity.status(HttpStatus.CREATED)
         .header("Location", "/api/players/" + created.id())

--- a/src/main/java/com/management/dto/KumiteGameRequestDTO.java
+++ b/src/main/java/com/management/dto/KumiteGameRequestDTO.java
@@ -1,35 +1,32 @@
 package com.management.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
-public class KumiteGameRequestDTO {
-  private Map<String, PlayerDTO> playersMap;
-  private List<String> refereeList;
-
-  private String gameDuration;
-
-  public Map<String, PlayerDTO> getPlayersMap() {
-    return playersMap;
-  }
-
-  public void setPlayersMap(Map<String, PlayerDTO> playersMap) {
-    this.playersMap = playersMap;
-  }
-
-  public List<String> getRefereeList() {
-    return refereeList;
-  }
-
-  public void setRefereeList(List<String> refereeList) {
-    this.refereeList = refereeList;
-  }
-
-  public String getGameDuration() {
-    return gameDuration;
-  }
-
-  public void setGameDuration(String gameDuration) {
-    this.gameDuration = gameDuration;
-  }
-}
+/**
+ * The request to create a match.
+ *
+ * <p>The constraints reject a malformed request at the boundary as a 400 naming every failing
+ * field; what they cannot see — that the two fighters carry one RED and one BLUE — stays a domain
+ * rule in {@code KumiteGameService}, because it reads the colour <em>values</em>, not the shape.
+ *
+ * @param playersMap exactly two fighters, keyed by a label the server ignores — the authoritative
+ *     colour is each fighter's own {@code color} field
+ * @param refereeList at least one referee name, none blank
+ * @param gameDuration seconds, optional; must be positive, and a positive value outside the
+ *     configured set falls back to the configured default
+ */
+public record KumiteGameRequestDTO(
+    @NotNull(message = "a match needs fighters")
+        @Size(min = 2, max = 2, message = "a match fields exactly two fighters")
+        Map<String, @NotNull(message = "a fighter must not be null") @Valid PlayerDTO> playersMap,
+    @NotEmpty(message = "a match needs at least one referee")
+        List<@NotBlank(message = "a referee name must not be blank") String> refereeList,
+    @Positive(message = "must be a positive number of seconds") @Nullable Integer gameDuration) {}

--- a/src/main/java/com/management/dto/PlayerDTO.java
+++ b/src/main/java/com/management/dto/PlayerDTO.java
@@ -1,38 +1,15 @@
 package com.management.dto;
 
-public class PlayerDTO {
-  private String id;
-  private String name;
-  private String color;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-  public PlayerDTO() {}
-
-  public PlayerDTO(String name, String color) {
-    this.name = name;
-    this.color = color;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getColor() {
-    return color;
-  }
-
-  public void setColor(String color) {
-    this.color = color;
-  }
-}
+/**
+ * A fighter inside a match-creation request.
+ *
+ * <p>The colour is constrained only as present; whether it names a real colour is decided against
+ * {@code PlayerColor} in the service, where the failure carries its own exception type and 400
+ * mapping. The {@code id} field the class-based version carried is gone: it was never read.
+ */
+public record PlayerDTO(
+    @NotBlank(message = "a fighter needs a name") @Size(max = 100) String name,
+    @NotBlank(message = "a fighter needs a colour") String color) {}

--- a/src/main/java/com/management/dto/PlayerRequestDTO.java
+++ b/src/main/java/com/management/dto/PlayerRequestDTO.java
@@ -1,13 +1,8 @@
 package com.management.dto;
 
-public class PlayerRequestDTO {
-  private String name;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-}
+/** The request to create a standalone fighter. */
+public record PlayerRequestDTO(
+    @NotBlank(message = "a fighter needs a name") @Size(max = 100) String name) {}

--- a/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/management/exceptions/GlobalExceptionHandler.java
@@ -1,11 +1,19 @@
 package com.management.exceptions;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
@@ -94,6 +102,38 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   /**
+   * Bean Validation failures, with every failing field listed.
+   *
+   * <p>Overrides the base class's hook rather than declaring a separate {@code @ExceptionHandler} —
+   * two handlers competing for the same exception is the failure mode {@code
+   * workflow/patterns/error-handling.md} warns about. The per-field messages go in an {@code
+   * errors} extension property so the body stays machine-readable: a caller fixing three fields
+   * gets all three in one round trip, keyed by field path.
+   */
+  @Override
+  protected @Nullable ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    Map<String, String> errors = new LinkedHashMap<>();
+    ex.getBindingResult()
+        .getFieldErrors()
+        .forEach(
+            fieldError ->
+                errors.merge(
+                    fieldError.getField(),
+                    String.valueOf(fieldError.getDefaultMessage()),
+                    (first, second) -> first + "; " + second));
+
+    ProblemDetail problem =
+        ProblemDetail.forStatusAndDetail(status, "The request failed validation.");
+    problem.setTitle("Invalid request");
+    problem.setProperty("errors", errors);
+    return handleExceptionInternal(ex, problem, headers, status, request);
+  }
+
+  /**
    * A lifecycle operation on a match whose state does not allow it.
    *
    * <p>409 rather than 400: the request was syntactically fine and the match exists — it is the
@@ -120,10 +160,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
    *
    * <p>So the message goes to the log, exactly as the catch-all does it, and the caller gets a
    * fixed detail. Validation whose wording is genuinely useful raises {@link
-   * InvalidGameRequestException} instead and keeps its message.
-   *
-   * <p>Still a stopgap: the service parses the match duration out of a string by hand, and hand
-   * validation inside a service is what Epic #38 replaces with constraints at the edge.
+   * InvalidGameRequestException} instead and keeps its message; request-shape validation is
+   * constraints at the edge since #39 and never reaches this handler.
    */
   @ExceptionHandler(IllegalArgumentException.class)
   public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {

--- a/src/main/java/com/management/services/KumiteGameService.java
+++ b/src/main/java/com/management/services/KumiteGameService.java
@@ -42,19 +42,16 @@ public class KumiteGameService {
 
   public KumiteGame createKumiteGame(KumiteGameRequestDTO gameRequestDTO) {
 
-    validateGameRequestDTO(gameRequestDTO);
-
     // Resolve every colour before creating anything. The colours are what decide whether this
     // request can produce a valid match, and a player saved for a request that turns out to be
     // malformed cannot be taken back -- this service has no transaction to roll back with, because
     // the database is a standalone MongoDB. See validateColours for what makes a set valid.
     Map<PlayerColor, PlayerDTO> byColour = new EnumMap<>(PlayerColor.class);
     gameRequestDTO
-        .getPlayersMap()
+        .playersMap()
         .forEach(
             (key, playerDTO) -> {
-              PlayerColor playerColor =
-                  KumiteGameManagementUtils.mapPlayerColor(playerDTO.getColor());
+              PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(playerDTO.color());
               PlayerDTO clash = byColour.put(playerColor, playerDTO);
               if (clash != null) {
                 throw new InvalidGameRequestException(
@@ -67,14 +64,12 @@ public class KumiteGameService {
 
     Map<PlayerColor, Player> playersMap = new EnumMap<>(PlayerColor.class);
     byColour.forEach(
-        (playerColor, requested) -> {
-          PlayerRequestDTO playerRequestDTO = new PlayerRequestDTO();
-          playerRequestDTO.setName(requested.getName());
-          playersMap.put(playerColor, gameHelperService.createNewPlayer(playerRequestDTO));
-        });
+        (playerColor, requested) ->
+            playersMap.put(
+                playerColor,
+                gameHelperService.createNewPlayer(new PlayerRequestDTO(requested.name()))));
 
-    List<Referee> refereesList =
-        gameRequestDTO.getRefereeList().stream().map(Referee::new).toList();
+    List<Referee> refereesList = gameRequestDTO.refereeList().stream().map(Referee::new).toList();
 
     Duration gameDuration = determineGameDuration(gameRequestDTO);
 
@@ -187,15 +182,6 @@ public class KumiteGameService {
     return saveGame(kumiteGame);
   }
 
-  private void validateGameRequestDTO(KumiteGameRequestDTO gameRequestDTO) {
-    if (gameRequestDTO.getPlayersMap() == null || gameRequestDTO.getPlayersMap().isEmpty()) {
-      throw new InvalidGameRequestException("Players cannot be empty");
-    }
-    if (gameRequestDTO.getRefereeList() == null || gameRequestDTO.getRefereeList().isEmpty()) {
-      throw new InvalidGameRequestException("Referee list cannot be empty");
-    }
-  }
-
   /**
    * Enforces the one-of-each-colour rule at the point of creation.
    *
@@ -224,9 +210,8 @@ public class KumiteGameService {
   }
 
   private Duration determineGameDuration(KumiteGameRequestDTO gameRequestDTO) {
-    if (gameRequestDTO.getGameDuration() != null) {
-      Duration requestedDuration =
-          Duration.ofSeconds(Integer.parseInt(gameRequestDTO.getGameDuration()));
+    if (gameRequestDTO.gameDuration() != null) {
+      Duration requestedDuration = Duration.ofSeconds(gameRequestDTO.gameDuration());
       if (config.getOptionalDurations().contains(requestedDuration)) {
         return requestedDuration;
       }

--- a/src/main/java/com/management/services/PlayerService.java
+++ b/src/main/java/com/management/services/PlayerService.java
@@ -23,7 +23,7 @@ public class PlayerService {
   @Autowired @Lazy private GameHelperService gameHelperService;
 
   public Player createPlayer(PlayerRequestDTO playerDTO) {
-    Player newPlayer = new Player(playerDTO.getName());
+    Player newPlayer = new Player(playerDTO.name());
     return playerRepository.save(newPlayer);
   }
 

--- a/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
@@ -1,6 +1,7 @@
 package com.management.kumitegametests;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -71,7 +72,7 @@ class KumiteGameControllerSliceTest extends WebSliceTestBase {
                         "blue": { "name": "Sato",  "color": "BLUE" }
                       },
                       "refereeList": ["Test Referee"],
-                      "gameDuration": "90"
+                      "gameDuration": 90
                     }
                     """))
         .andExpect(status().isCreated())
@@ -402,22 +403,100 @@ class KumiteGameControllerSliceTest extends WebSliceTestBase {
         .andExpect(jsonPath("$.detail").value("Match game-1 is FINISHED and cannot be started."));
   }
 
+  /**
+   * A well-formed request the domain rejects: shape validation passed, the colour rule did not.
+   *
+   * <p>The body must be structurally valid, or {@code @Valid} rejects it before the controller —
+   * and therefore before the stubbed service — is ever reached.
+   */
   @Test
   void createKumiteGame_whenTheServiceRejectsTheRequest_returns400WithTheReason() throws Exception {
     given(kumiteGameService.createKumiteGame(any()))
-        .willThrow(new InvalidGameRequestException("Players cannot be empty"));
+        .willThrow(
+            new InvalidGameRequestException(
+                "A match fields exactly one fighter per colour, but two were given as RED."));
 
     mockMvc
         .perform(
             post("/api/kumitegame")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"playersMap\":{},\"refereeList\":[]}"))
+                .content(
+                    """
+                    {
+                      "playersMap": {
+                        "red":  { "name": "Kenji", "color": "RED" },
+                        "blue": { "name": "Sato",  "color": "RED" }
+                      },
+                      "refereeList": ["Test Referee"]
+                    }
+                    """))
         // Reached the catch-all and reported a client mistake as a server fault before #36.
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.status").value(400))
         // Echoed because this project wrote it: the caller can act on it and it says nothing
         // internal.
-        .andExpect(jsonPath("$.detail").value("Players cannot be empty"));
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    "A match fields exactly one fighter per colour, but two were given as RED."));
+  }
+
+  /**
+   * Bean Validation at the boundary (#39): every failing field reported, in one round trip.
+   *
+   * <p>Three distinct failures in one request — a blank fighter name (a nested constraint, which
+   * only fires because the map values are marked {@code @Valid}), a one-fighter map, and an empty
+   * referee list. The service is never reached; no stubbing is needed or wanted.
+   */
+  @Test
+  void createKumiteGame_whenSeveralFieldsAreInvalid_returns400ListingEveryFailure()
+      throws Exception {
+    mockMvc
+        .perform(
+            post("/api/kumitegame")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "playersMap": {
+                        "red": { "name": "", "color": "RED" }
+                      },
+                      "refereeList": []
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.title").value("Invalid request"))
+        .andExpect(jsonPath("$.errors").value(hasKey("playersMap[red].name")))
+        .andExpect(jsonPath("$.errors").value(hasKey("playersMap")))
+        .andExpect(jsonPath("$.errors").value(hasKey("refereeList")));
+  }
+
+  /**
+   * A {@code null} fighter is the caller's mistake, not a server fault.
+   *
+   * <p>{@code @Valid} on the map values skips nulls entirely (per the Bean Validation spec), so
+   * without {@code @NotNull} beside it this request sailed through validation and died in the
+   * service as a 500. The container-element constraint is what turns it into a 400.
+   */
+  @Test
+  void createKumiteGame_whenOneFighterIsNull_returns400NotServerError() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/kumitegame")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "playersMap": {
+                        "red":  null,
+                        "blue": { "name": "Sato", "color": "BLUE" }
+                      },
+                      "refereeList": ["Test Referee"]
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errors").value(hasKey("playersMap[red]")));
   }
 
   /**
@@ -446,17 +525,20 @@ class KumiteGameControllerSliceTest extends WebSliceTestBase {
         .andExpect(content().string(not(containsString("secret"))));
   }
 
+  /**
+   * A non-numeric duration dies at binding, before any code runs (#39).
+   *
+   * <p>{@code gameDuration} is an {@code Integer} now, so the framework rejects text that is not a
+   * number as an unreadable body — no service stub, no hand parse, no {@code NumberFormatException}
+   * surfacing from below.
+   */
   @Test
   void createKumiteGame_whenTheDurationIsNotNumeric_returns400() throws Exception {
-    given(kumiteGameService.createKumiteGame(any()))
-        .willThrow(new NumberFormatException("For input string: \"two minutes\""));
-
     mockMvc
         .perform(
             post("/api/kumitegame")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"gameDuration\":\"two minutes\"}"))
-        // NumberFormatException is an IllegalArgumentException, so one handler covers both.
         .andExpect(status().isBadRequest());
   }
 

--- a/src/test/java/com/management/kumitegametests/KumiteGameCreationTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameCreationTest.java
@@ -87,13 +87,10 @@ class KumiteGameCreationTest {
   }
 
   private static KumiteGameRequestDTO request(PlayerDTO... fighters) {
-    KumiteGameRequestDTO dto = new KumiteGameRequestDTO();
     Map<String, PlayerDTO> byKey = new java.util.LinkedHashMap<>();
     for (int i = 0; i < fighters.length; i++) {
       byKey.put("fighter" + i, fighters[i]);
     }
-    dto.setPlayersMap(byKey);
-    dto.setRefereeList(List.of("Referee One"));
-    return dto;
+    return new KumiteGameRequestDTO(byKey, List.of("Referee One"), null);
   }
 }

--- a/src/test/java/com/management/kumitegametests/KumiteGameFlowIT.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameFlowIT.java
@@ -123,7 +123,7 @@ class KumiteGameFlowIT extends IntegrationTestBase {
             "blue": { "name": "Sato",  "color": "RED" }
           },
           "refereeList": ["Referee One"],
-          "gameDuration": "90"
+          "gameDuration": 90
         }
         """;
 
@@ -152,7 +152,7 @@ class KumiteGameFlowIT extends IntegrationTestBase {
             "blue": { "name": "Sato",  "color": "BLUE" }
           },
           "refereeList": ["Referee One"],
-          "gameDuration": "90"
+          "gameDuration": 90
         }
         """;
 

--- a/src/test/java/com/management/kumitegametests/PlayerControllerSliceTest.java
+++ b/src/test/java/com/management/kumitegametests/PlayerControllerSliceTest.java
@@ -93,6 +93,25 @@ class PlayerControllerSliceTest extends WebSliceTestBase {
                     JsonCompareMode.STRICT));
   }
 
+  /**
+   * Bean Validation on the fighter body (#39): a blank name is rejected at the boundary, naming the
+   * field, and the service is never consulted.
+   */
+  @Test
+  void createPlayer_whenTheNameIsBlank_returns400NamingTheField() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"  \"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.title").value("Invalid request"))
+        .andExpect(jsonPath("$.errors.name").value("a fighter needs a name"));
+
+    then(playerService).shouldHaveNoInteractions();
+  }
+
   @Test
   void getPlayer_whenTheFighterIsMissing_returns404AsProblemDetail() throws Exception {
     given(playerService.getPlayer(anyString()))


### PR DESCRIPTION
Closes #39, closes #40. Completes epic #38.

## What this does

Bad input is now rejected at the boundary as a 400 naming every failing field, instead of failing somewhere in the service layer as a generic error. The request DTOs became records in the same pass, as the epic prescribed.

### #39 — Bean Validation at the edge

- `spring-boot-starter-validation` added (not transitive through the web starter since Boot 2.3 — annotations were inert without it).
- Constraints on all three request types: fighter names `@NotBlank @Size(max=100)`, colour `@NotBlank`, `playersMap` `@NotEmpty @Size(min=2,max=2)` with `@Valid` on the map values so nested constraints actually fire, `refereeList` `@NotEmpty` with `@NotBlank` elements, `gameDuration` `@Positive` and optional.
- `@Valid` on both `@RequestBody` parameters.
- **`gameDuration` is now `Integer`, not `String`.** Non-numeric input dies at binding as a 400 from the framework's own unreadable-body handling — the hand `Integer.parseInt` is gone. The request contract is now a JSON number (`"gameDuration": 90`); tests updated accordingly.
- **Validation failures are reported through the base class's hook**, not a competing `@ExceptionHandler`: `handleMethodArgumentNotValid` is overridden to return a problem detail with an `errors` extension property mapping each failing field path to its message — all fields in one round trip, machine-readable, per `workflow/patterns/error-handling.md`.
- `validateGameRequestDTO` (the two hand-written emptiness checks) is deleted. The one-RED-one-BLUE rule stays in the service — it reads colour *values*, which constraints cannot.

### #40 — records

`KumiteGameRequestDTO`, `PlayerDTO`, `PlayerRequestDTO` are records with constraints on their components. The response types (`KumiteGameResponse`, `PlayerResponse`, `PlayerSummary`) were already records since epic #32, which is why the issue's five-file count no longer matched — nothing else remained to convert.

## Decisions worth knowing

- **`PlayerDTO.id` is deleted.** The class-based version carried an `id` field that nothing ever read; a client sending it was silently ignored before and still is (Boot's Jackson ignores unknown properties), so removing it changes no observable behaviour.
- **A numeric-but-unconfigured duration (e.g. 100) still falls back silently to the default**, as before. The issue explicitly blessed "`Integer` plus the existing configuration check" and the allowed set is configuration, which annotations cannot see. Flagged below as a finding rather than changed.
- Constraint messages are written for the caller ("a match fields exactly two fighters"), since the `errors` map is the payload a client acts on.
- **Self-review caught and fixed before commit:** map values are `@NotNull @Valid` — `@Valid` alone skips null values per the Bean Validation spec, so `"red": null` sailed through and died in the service as a 500 (empirically confirmed, now a 400 with a test); `playersMap` uses `@NotNull` + `@Size` instead of `@NotEmpty` + `@Size` so an empty map produces one message, not two merged ones; and the `gameDuration` javadoc now matches the actual contract (non-positive → 400, positive-but-unconfigured → default).

## Findings surfaced, not changed (engineer's call)

1. **Silent duration fallback:** a caller requesting `"gameDuration": 100` gets a 120-second match with no indication their value was ignored (beyond the returned `remainingSeconds`). Rejecting with a 400 naming the allowed set would be more honest — but the allowed set lives in config, so it would be a service-level `InvalidGameRequestException`, not an annotation. Cheap to do if wanted.
2. **Slice tests now exercise real validation** (no service stubbing for the failure cases), which locks the constraint set: removing a constraint fails a test, per the pattern's verification rule.

## Verification

`mvn verify` green locally: 103 fast-suite tests, 11 integration tests, coverage floor met. New tests: multi-field failure listing all three errors at once (including a nested map-value path, proving `@Valid` container-element validation fires), a `null` fighter answered 400 not 500, blank fighter name at `/api/players`, non-numeric duration 400 at binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
