### PR TITLE
Match outcome and rules engine (epic #68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,11 @@ Settled rules. Anything not listed here is either unbuilt (tracked as a GitHub i
 | Scoring | IPPON = 3, WAZA-ARI = 2, YUKO = 1 |
 | Game durations | 90s / **120s default** / 180s, loaded from config |
 | Game states | QUEUED, RUNNING, PAUSED, FINISHED |
+| Winning score | **8 by default** (`game.winning-points`) — a trigger, never a cap |
+| Foul limit | **4 by default** (`game.fouls-ending-match`) ends the match against the offender |
+| Foul stages | CHUI1 → CHUI2 → CHUI3 → HANSOKU_CHUI → HANSOKU → SHIKKAKU, derived from the count |
+| Clock increments | 10s / 30s (`game.clock-increments`) |
+| Match end reasons | POINTS_THRESHOLD, FOUL_LIMIT, TIME_EXPIRED, DISQUALIFICATION, KIKEN, REFEREE_OVERRIDE |
 
 **Valid state transitions.** Anything not in this table is illegal.
 
@@ -44,12 +49,16 @@ Settled rules. Anything not listed here is either unbuilt (tracked as a GitHub i
 | RUNNING | PAUSED, FINISHED |
 | PAUSED | RUNNING, FINISHED |
 
-The table is enforced. Each lifecycle method in `KumiteGameService` names its allowed starting states (start: QUEUED; pause: RUNNING; resume: PAUSED; end: RUNNING or PAUSED — the verbs are narrower than the state machine, since only a paused match can be *resumed*), and an illegal call surfaces as HTTP 409 via `IllegalStateTransitionException`. The full transition table also lives as data on `GameState` (`canTransitionTo`) for the planned Game Orchestrator.
+The table is enforced. Each lifecycle method in `KumiteGameService` names its allowed starting states (start: QUEUED; pause: RUNNING; resume: PAUSED; end: RUNNING or PAUSED — the verbs are narrower than the state machine, since only a paused match can be *resumed*), and an illegal call surfaces as HTTP 409 via `IllegalStateTransitionException`. The full transition table also lives as data on `GameState` (`canTransitionTo`). A match also finishes on its own, without any lifecycle call, when the rules engine says so — see below.
+
+**The rules engine** (`com.management.rules`) decides outcomes; it is the component the docs call the Game Orchestrator. `MatchOutcomeEvaluator` holds two injected lists — `MatchEndCondition` beans (is the match over, and why) and `WinnerRule` beans sorted by `@Order` (who won, first rule to answer wins) — and `KumiteGameService` calls it after every point, foul and disqualification, then applies and persists the answer. Adding a rule means adding a class; no existing rule changes.
+
+Winner priority: disqualification → higher score → SENSHU → draw. **SENSHU is captured as it happens** (first fighter to score, recorded on the match), because it cannot be reconstructed later. Ending is idempotent: the first condition to fire owns the result, and a finished match cannot be scored against.
 
 **Known vocabulary deviations in code** (each has an issue):
 - `PointsType.WAZARI` is missing the hyphen of the WKF's **WAZA-ARI**. It is public API surface — clients send `pointType=WAZARI`. #102 renamed `YOKO` to `YUKO` on the same grounds, so this is the last spelling left out of step with the rulebook.
 - `PlayerColor` has only `RED` / `BLUE`; the AKA/AO names appear nowhere in code.
-- `FoulTypes` (`CHUI1, CHUI2, CHUI3, HANSOKU_CHUI, HANSOKU, SHIKKAKU`) is declared but **never referenced**. Fouls are currently a plain counter with no progression.
+- `FoulTypes` is now derived from the foul count (`FoulTypes.forCount`). With the default limit of 4 the match ends at `HANSOKU_CHUI`, so `HANSOKU`'s point award and `SHIKKAKU`'s disqualification are only reached by accumulation if the limit is raised — the two rules the issues state ("CHUI up to 3, then HANSOKU CHUI" and "4 fouls ends the match") do not both fit one progression. Both are expressed as configuration rather than picked between in code. **Worth an explicit decision.**
 - The project wiki calls the in-progress state `STARTED`; the code says `RUNNING`. **The code is authoritative.**
 
 ## Stack
@@ -172,10 +181,10 @@ There are two aggregate roots with their own controller/service/repository stack
 
 ## Key Wiring to Know
 
-- `KumiteGameController` at `/api/kumitegame` — owns game creation, retrieval, point/foul mutations, and winner assignment; every route delegates to `KumiteGameService`
+- `KumiteGameController` at `/api/kumitegame` — owns game creation, retrieval, point/foul mutations, winner assignment, disqualification, KIKEN, referee override and clock extension; every route delegates to `KumiteGameService`
 - `PlayerController` at `/api/players` — owns player CRUD
 - `PointsType` enum carries its `PointStrategy` instance — `PointStrategy` declares `addPoint(Points)` / `removePoint(Points)`, which mutate the score in place. There is no method that returns a value.
-- `GameProperties` (a `@ConfigurationProperties("game")` record, validated at startup) binds game durations from `game.*` in `application.properties` — durations are configuration, not code
+- `GameProperties` (a `@ConfigurationProperties("game")` record, validated at startup) binds every rule value from `game.*` in `application.properties` — durations, the winning score, the foul limit and the clock increments are configuration, not code
 - MongoDB connection is configured via environment variables (`MONGO_HOST`, `MONGO_PORT`, `MONGO_DB`), defaulting to `localhost:27017/kumitedb`. They bind through **`spring.mongodb.*`**, not `spring.data.mongodb.*` — Boot 4 split that namespace into driver-level (`spring.mongodb`) and repository-level (`spring.data.mongodb`). Both still resolve, so using the wrong one fails silently by falling back to the default host.
 
 ## The API Response Contract
@@ -184,7 +193,7 @@ Settled in Epic #32. Persistence types do not cross the HTTP boundary in either 
 
 | Response type | Endpoint | Shape |
 |---|---|---|
-| `KumiteGameResponse` | everything under `/api/kumitegame` | `id`, `gameState`, `remainingSeconds`, `red`, `blue`, `referees`, `winner` |
+| `KumiteGameResponse` | everything under `/api/kumitegame` | `id`, `gameState`, `remainingSeconds`, `red`, `blue`, `referees`, `winner`, `endReason`, `overridden` |
 | `PlayerSummary` | nested as `red` / `blue` | `id`, `name`, `points`, `fouls` |
 | `PlayerResponse` | `/api/players` | `id`, `name`, `points`, `fouls` |
 
@@ -197,7 +206,7 @@ Settled in Epic #32. Persistence types do not cross the HTTP boundary in either 
 - **Referees are names.** A `List<String>`, not a list of objects, until a referee has more than a name.
 - **Enums serialise as their names**, uppercase, exactly as declared.
 
-**Mutations return the new state.** The four scoring endpoints answer with the updated `KumiteGameResponse` rather than a confirmation sentence, so a scoreboard never needs a follow-up read. `DELETE /api/players/{id}` answers 204 with no body.
+**Mutations return the new state.** The scoring, disqualification, KIKEN, override and add-time endpoints all answer with the updated `KumiteGameResponse` rather than a confirmation sentence, so a scoreboard never needs a follow-up read — including when the mutation is what finished the match. `DELETE /api/players/{id}` answers 204 with no body.
 
 **Errors are RFC 9457 problem details** — `application/problem+json`, carrying `status`, `title` and `detail`. `GlobalExceptionHandler` extends `ResponseEntityExceptionHandler`, so the exceptions the framework itself raises are mapped too rather than falling through to the catch-all as 500s.
 
@@ -227,7 +236,7 @@ The two colour failures are deliberately different types: *not a colour* is the 
 
 - **Timer lifecycle wiring** — `GameTimer` class exists with basic structure and a test, but is not yet integrated into game lifecycle methods. WebSocket push to frontend not implemented. Persistence strategy for `remainingTime` recalculation on point/foul events not implemented.
 - **Game lifecycle endpoints** — `startGame`, `pauseGame`, `resumeGame`, `endGame` have no controller mappings
-- **Game Orchestrator** — evaluates game ending conditions after every point/foul, determines winner, updates state
+- **Clock-driven time expiry** — expiry is *observed* on the next scoring event, not pushed. A match left untouched past its duration stays open until something asks. Closing that needs the timer to emit events (see the timer item above).
 - **Spring Security and JWT** — not started
 - **Frontend** — not started
 

--- a/config/checkstyle/project-standards.xml
+++ b/config/checkstyle/project-standards.xml
@@ -55,9 +55,22 @@
       <property name="ignoreComments" value="true"/>
       <property name="message" value="java.md: Optional is a return type, never a parameter."/>
     </module>
+    <!--
+      Matches a field declaration only. A method is excluded by the parameter list its name is
+      followed by, so the generic part excludes "(" rather than "&gt;". Excluding "&gt;" stopped at
+      the inner bracket of a nested generic and let "private Optional&lt;List&lt;String&gt;&gt;
+      cache;" through. The tail allows end-of-line as well as "=" or ";", so a declaration the
+      formatter wrapped is still caught.
+
+      Without that method exclusion the pattern matched every method whose return type is Optional,
+      which is the one use java.md explicitly endorses and which its own worked example contains
+      ("private static Optional&lt;Grade&gt; parseGrade(...)"). A rule that forbids the thing its
+      standard prescribes is worse than no rule: it pushes authors towards returning null instead.
+    -->
     <module name="RegexpSinglelineJava">
       <property name="id" value="OptionalAsField"/>
-      <property name="format" value="^\s*(private|protected|public)\s+(static\s+|final\s+)*Optional&lt;"/>
+      <property name="format"
+                value="^\s*(private|protected|public)\s+(static\s+|final\s+)*Optional&lt;[^(]*&gt;\s+\w+\s*([=;]|$)"/>
       <property name="ignoreComments" value="true"/>
       <property name="message" value="java.md: Optional is a return type, never a field."/>
     </module>

--- a/src/main/java/com/management/config/GameProperties.java
+++ b/src/main/java/com/management/config/GameProperties.java
@@ -2,30 +2,39 @@ package com.management.config;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Match durations, bound from {@code game.*} in the standard configuration and validated at
- * startup.
+ * The rule values a match is run by, bound from {@code game.*} and validated at startup.
  *
- * <p>Replaces the hand-written {@code GameConfig}, which read its own properties file through the
- * classloader — outside the container, so it could not be substituted in a test, overridden per
- * environment, or validated before first use. Binding here gives all three for free, and the values
- * are rich types: {@code 120s} in the file arrives as a {@link Duration}, no hand parsing.
+ * <p>Every value here is a rule, not a constant: thresholds and durations change between rule
+ * revisions and between championships, and the project forbids any of them appearing in code.
+ * Binding them gives typed values, environment overrides and startup validation for free — {@code
+ * 120s} in the file arrives as a {@link Duration}, with no hand parsing.
  *
  * @param defaultDuration the match length used when a request names none, or names one outside the
  *     permitted set
  * @param optionalDurations the full set of match lengths a request may choose from
+ * @param winningPoints the score a fighter must <em>cross</em> to win; a trigger, never a cap
+ * @param foulsEndingMatch the number of fouls that ends a match against the fighter who committed
+ *     them
+ * @param clockIncrements the time additions a referee may apply to compensate for a late stop
  */
 @Validated
 @ConfigurationProperties("game")
 public record GameProperties(
-    @NotNull Duration defaultDuration, @NotEmpty List<Duration> optionalDurations) {
+    @NotNull Duration defaultDuration,
+    @NotEmpty List<Duration> optionalDurations,
+    @Positive int winningPoints,
+    @Positive int foulsEndingMatch,
+    @NotEmpty List<Duration> clockIncrements) {
 
   public GameProperties {
     optionalDurations = List.copyOf(optionalDurations);
+    clockIncrements = List.copyOf(clockIncrements);
   }
 }

--- a/src/main/java/com/management/controllers/KumiteGameController.java
+++ b/src/main/java/com/management/controllers/KumiteGameController.java
@@ -1,7 +1,9 @@
 package com.management.controllers;
 
+import com.management.dto.ClockAdjustmentRequest;
 import com.management.dto.KumiteGameRequestDTO;
 import com.management.dto.KumiteGameResponse;
+import com.management.dto.WinnerOverrideRequest;
 import com.management.mappers.KumiteGameMapper;
 import com.management.services.KumiteGameService;
 import jakarta.validation.Valid;
@@ -67,5 +69,36 @@ public class KumiteGameController {
       @PathVariable String gameId, @PathVariable String color) {
     return ResponseEntity.ok(
         KumiteGameMapper.toResponse(kumiteGameService.updateKumiteGameWinner(gameId, color)));
+  }
+
+  /** Puts a fighter out of the match; the rules engine awards the win to the opponent. */
+  @PutMapping("/{gameId}/disqualify/{color}")
+  public ResponseEntity<KumiteGameResponse> disqualify(
+      @PathVariable String gameId, @PathVariable String color) {
+    return ResponseEntity.ok(
+        KumiteGameMapper.toResponse(kumiteGameService.disqualify(gameId, color)));
+  }
+
+  /** Records a forfeit — KIKEN — against a fighter who did not appear or withdrew. */
+  @PutMapping("/{gameId}/kiken/{color}")
+  public ResponseEntity<KumiteGameResponse> forfeit(
+      @PathVariable String gameId, @PathVariable String color) {
+    return ResponseEntity.ok(KumiteGameMapper.toResponse(kumiteGameService.forfeit(gameId, color)));
+  }
+
+  /** Replaces the result with a referee's decision. The reason is required. */
+  @PutMapping("/{gameId}/override-winner")
+  public ResponseEntity<KumiteGameResponse> overrideWinner(
+      @PathVariable String gameId, @Valid @RequestBody WinnerOverrideRequest request) {
+    return ResponseEntity.ok(
+        KumiteGameMapper.toResponse(kumiteGameService.overrideWinner(gameId, request)));
+  }
+
+  /** Puts time back on the clock after a stop that came late. */
+  @PutMapping("/{gameId}/add-time")
+  public ResponseEntity<KumiteGameResponse> addTime(
+      @PathVariable String gameId, @Valid @RequestBody ClockAdjustmentRequest request) {
+    return ResponseEntity.ok(
+        KumiteGameMapper.toResponse(kumiteGameService.addTime(gameId, request)));
   }
 }

--- a/src/main/java/com/management/dto/ClockAdjustmentRequest.java
+++ b/src/main/java/com/management/dto/ClockAdjustmentRequest.java
@@ -1,0 +1,21 @@
+package com.management.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * A referee's request to put time back on the clock.
+ *
+ * <p>Seconds as an integer, so a non-numeric value dies at binding rather than in a hand parse.
+ * Which values are actually permitted is configuration — {@code game.clock-increments} — and is
+ * checked in the service, because a constraint cannot see it.
+ *
+ * @param seconds how much time to add; must be one of the configured increments
+ * @param addedBy who added it. Caller-supplied until the security epic (#81) supplies an
+ *     authenticated identity.
+ */
+public record ClockAdjustmentRequest(
+    @Positive(message = "time added must be a positive number of seconds") int seconds,
+    @NotBlank(message = "a clock adjustment must record who made it") @Size(max = 100)
+        String addedBy) {}

--- a/src/main/java/com/management/dto/KumiteGameResponse.java
+++ b/src/main/java/com/management/dto/KumiteGameResponse.java
@@ -1,6 +1,7 @@
 package com.management.dto;
 
 import com.management.enums.GameState;
+import com.management.enums.MatchEndReason;
 import com.management.enums.PlayerColor;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
@@ -25,6 +26,16 @@ import org.jspecify.annotations.Nullable;
  * See {@code workflow/patterns/service-exposure.md}: a field whose format cannot be misread needs
  * no format policy. {@code startTime} is deliberately absent — it is internal bookkeeping used to
  * compute elapsed time, and a client holding {@code remainingSeconds} has no use for it.
+ *
+ * <p><strong>The result explains itself.</strong> A colour alone does not say whether a match was
+ * won on points, forfeited, or set aside by a referee, and those read very differently on a
+ * scoreboard. {@code endReason} says why the match ended and {@code overridden} says whether the
+ * rules engine or a human produced the result; both are {@code null}/{@code false} while the match
+ * is still being fought. The rule that decided it stays internal — it is audit detail, not
+ * something a scoreboard renders.
+ *
+ * @param endReason why the match ended, or {@code null} while it is open
+ * @param overridden whether a referee set this result rather than the rules engine
  */
 public record KumiteGameResponse(
     String id,
@@ -33,4 +44,6 @@ public record KumiteGameResponse(
     PlayerSummary red,
     PlayerSummary blue,
     List<String> referees,
-    @Nullable PlayerColor winner) {}
+    @Nullable PlayerColor winner,
+    @Nullable MatchEndReason endReason,
+    boolean overridden) {}

--- a/src/main/java/com/management/dto/WinnerOverrideRequest.java
+++ b/src/main/java/com/management/dto/WinnerOverrideRequest.java
@@ -1,0 +1,22 @@
+package com.management.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A referee's decision to set the result themselves.
+ *
+ * <p>The reason is required by a constraint rather than by a service check, so an override with no
+ * justification is refused at the boundary — an override is an exception to the rules, and the
+ * reason is the only record of why it was made.
+ *
+ * @param winner the colour to declare, or {@code null} to declare a draw
+ * @param reason why the rules engine's result is being overruled; required
+ * @param decidedBy who decided. A caller-supplied name until the security epic (#81) provides an
+ *     authenticated identity to record instead — the field stays, its source changes.
+ */
+public record WinnerOverrideRequest(
+    @Nullable String winner,
+    @NotBlank(message = "an override must record why it was made") @Size(max = 500) String reason,
+    @NotBlank(message = "an override must record who decided") @Size(max = 100) String decidedBy) {}

--- a/src/main/java/com/management/enums/FoulTypes.java
+++ b/src/main/java/com/management/enums/FoulTypes.java
@@ -1,10 +1,59 @@
 package com.management.enums;
 
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The penalty stages a fighter passes through, in order of severity.
+ *
+ * <p><strong>Derived, never stored.</strong> A fighter's stage is a function of their foul count —
+ * {@link #forCount(int)} — so the two cannot disagree. Storing the stage alongside the count would
+ * be two records of one fact, which is the defect epic #47 spent its whole length removing.
+ *
+ * <p>The two later stages carry consequences beyond a warning: {@link #HANSOKU} awards points to
+ * the opponent, and {@link #SHIKKAKU} disqualifies. Whether either is reachable by accumulation
+ * depends on {@code game.fouls-ending-match}: at the default of 4 the match ends at {@link
+ * #HANSOKU_CHUI}, so the later stages arrive only through a referee's explicit disqualification.
+ */
 public enum FoulTypes {
   CHUI1,
   CHUI2,
   CHUI3,
   HANSOKU_CHUI,
-  HANSOKU,
-  SHIKKAKU
+  HANSOKU(PointsType.IPPON),
+  SHIKKAKU;
+
+  private final @Nullable PointsType opponentAward;
+
+  FoulTypes() {
+    this(null);
+  }
+
+  FoulTypes(@Nullable PointsType opponentAward) {
+    this.opponentAward = opponentAward;
+  }
+
+  /**
+   * The stage a fighter is at after {@code fouls} fouls, or empty when they have none.
+   *
+   * <p>Counts beyond the last stage stay at the last stage: the progression cannot escalate past
+   * disqualification, and a count that high means the match should already have ended.
+   */
+  public static Optional<FoulTypes> forCount(int fouls) {
+    if (fouls <= 0) {
+      return Optional.empty();
+    }
+    FoulTypes[] stages = values();
+    return Optional.of(stages[Math.min(fouls, stages.length) - 1]);
+  }
+
+  /** The points this stage hands the opponent, or empty when it is a warning only. */
+  public Optional<PointsType> opponentAward() {
+    return Optional.ofNullable(opponentAward);
+  }
+
+  /** Whether reaching this stage puts the fighter out of the match. */
+  public boolean isDisqualifying() {
+    return this == SHIKKAKU;
+  }
 }

--- a/src/main/java/com/management/enums/MatchEndReason.java
+++ b/src/main/java/com/management/enums/MatchEndReason.java
@@ -1,0 +1,24 @@
+package com.management.enums;
+
+/**
+ * Why a match ended.
+ *
+ * <p>Recorded on the match, because the result alone does not explain itself: a decided match and a
+ * forfeit look identical from the winner's colour. Every ending condition names one of these, and a
+ * match that has ended has exactly one — the first condition to fire wins, and a later one never
+ * overwrites it.
+ */
+public enum MatchEndReason {
+  /** A fighter crossed the winning score. */
+  POINTS_THRESHOLD,
+  /** A fighter accumulated the configured number of fouls. */
+  FOUL_LIMIT,
+  /** The clock reached zero. */
+  TIME_EXPIRED,
+  /** A referee disqualified a fighter. */
+  DISQUALIFICATION,
+  /** A fighter did not appear, or withdrew — KIKEN. */
+  KIKEN,
+  /** A referee ended the match themselves, overriding the rules engine. */
+  REFEREE_OVERRIDE
+}

--- a/src/main/java/com/management/mappers/KumiteGameMapper.java
+++ b/src/main/java/com/management/mappers/KumiteGameMapper.java
@@ -42,7 +42,9 @@ public final class KumiteGameMapper {
         toSummary(fighter(gameWithFighters, PlayerColor.RED)),
         toSummary(fighter(gameWithFighters, PlayerColor.BLUE)),
         game.getReferees().stream().map(Referee::name).toList(),
-        game.getWinner());
+        game.getWinner(),
+        game.getEndReason().orElse(null),
+        game.isDecidedByReferee());
   }
 
   private static PlayerSummary toSummary(Player player) {

--- a/src/main/java/com/management/models/ClockAdjustment.java
+++ b/src/main/java/com/management/models/ClockAdjustment.java
@@ -1,0 +1,17 @@
+package com.management.models;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * Time a referee added to the clock, and who added it.
+ *
+ * <p>Extending a match changes what can happen in it, so each addition is recorded rather than
+ * silently folded into the remaining time. The actor is a caller-supplied name today; the security
+ * epic (#81) replaces it with an authenticated identity.
+ *
+ * @param added how much time was added
+ * @param addedAt when it was added
+ * @param addedBy who added it
+ */
+public record ClockAdjustment(Duration added, LocalDateTime addedAt, String addedBy) {}

--- a/src/main/java/com/management/models/GameTimer.java
+++ b/src/main/java/com/management/models/GameTimer.java
@@ -68,6 +68,53 @@ public class GameTimer {
     this.startTime = null;
   }
 
+  /**
+   * Stops the clock, reporting the time that was left on it.
+   *
+   * <p>For a match that ends before its time is up — a threshold crossing, a forfeit. {@link
+   * #stop()} zeroes the clock, which makes an early finish indistinguishable from one that ran the
+   * full duration; this keeps the evidence.
+   */
+  public Duration stopAndReport() {
+    Duration left = getRemainingTime();
+    this.remainingTime = left;
+    this.startTime = null;
+    return left;
+  }
+
+  /**
+   * Adds time to the clock, whether it is running or paused.
+   *
+   * <p>Adding to a <em>running</em> clock is the case that goes wrong: the remaining time is only
+   * meaningful together with the instant it was last measured from, so the elapsed time so far is
+   * banked first and the clock restarted from now. Adding to the total without doing that would
+   * hand back the added time and then immediately subtract the same elapsed period again.
+   *
+   * @param extra a positive duration; zero or negative is rejected, because removing time is a
+   *     different operation with different rules and is deliberately not offered here
+   */
+  public void add(Duration extra) {
+    if (extra.isNegative() || extra.isZero()) {
+      throw new IllegalArgumentException(
+          "Time added to the clock must be positive, but was " + extra);
+    }
+    if (startTime != null) {
+      this.remainingTime = clampToZero(remainingTime.minus(elapsedSinceStart(startTime)));
+      this.startTime = LocalDateTime.now(clock);
+    }
+    this.remainingTime = remainingTime.plus(extra);
+  }
+
+  /** Whether the clock is currently counting down. */
+  public boolean isRunning() {
+    return startTime != null;
+  }
+
+  /** The instant the clock last started counting, or {@code null} if it is not running. */
+  public @Nullable LocalDateTime startedAt() {
+    return startTime;
+  }
+
   /** Time left on the clock, never negative: a match that ran long reports zero, not minus. */
   public Duration getRemainingTime() {
     if (startTime != null) {

--- a/src/main/java/com/management/models/KumiteGame.java
+++ b/src/main/java/com/management/models/KumiteGame.java
@@ -2,13 +2,16 @@ package com.management.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.management.enums.GameState;
+import com.management.enums.MatchEndReason;
 import com.management.enums.PlayerColor;
 import com.management.exceptions.PlayerNotFoundException;
 import com.management.models.converters.LegacyWinnerConverter;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceCreator;
@@ -67,6 +70,27 @@ public class KumiteGame {
   @Nullable
   private PlayerColor winner;
 
+  /**
+   * The colour that scored first — SENSHU — or {@code null} while nobody has scored.
+   *
+   * <p>Captured as it happens, because it cannot be reconstructed afterwards: the score alone does
+   * not say who reached it first. Without it a level match at time expiry has nothing to resolve
+   * on.
+   */
+  @Nullable private PlayerColor senshu;
+
+  /** Why the match ended, or {@code null} while it is still open. */
+  @Nullable private MatchEndReason endReason;
+
+  /** The rule that decided the winner, or {@code null} while undecided. */
+  @Nullable private String decidedBy;
+
+  /** The referee's override, or {@code null} when the result is the rules engine's. */
+  @Nullable private RefereeOverride refereeOverride;
+
+  /** Every time addition a referee applied, in the order they were applied. */
+  private List<ClockAdjustment> clockAdjustments = new ArrayList<>();
+
   private LocalDateTime startTime;
   private Duration remainingTime;
   private Duration gameDuration;
@@ -92,11 +116,135 @@ public class KumiteGame {
   }
 
   public void updateWinner(PlayerColor color) {
+    requireFields(color);
+    setWinner(color);
+  }
+
+  private void requireFields(PlayerColor color) {
     if (playerIds == null || !playerIds.containsKey(color)) {
       throw new PlayerNotFoundException(
           "Match " + id + " has no " + color + " fighter to declare the winner.");
     }
-    setWinner(color);
+  }
+
+  /**
+   * Records who scored first, once.
+   *
+   * <p>SENSHU is "the first to score", so the second call is deliberately a no-op rather than an
+   * overwrite — otherwise the last scorer would end up holding it.
+   */
+  public void recordFirstScorer(PlayerColor color) {
+    if (senshu == null) {
+      senshu = color;
+    }
+  }
+
+  public Optional<PlayerColor> getSenshu() {
+    return Optional.ofNullable(senshu);
+  }
+
+  /**
+   * Forgets who scored first.
+   *
+   * <p>For a score corrected back to zero: the fighter did not, after all, score first, and leaving
+   * the claim in place would let it decide a level match at time expiry.
+   */
+  public void clearFirstScorer() {
+    this.senshu = null;
+  }
+
+  /**
+   * Applies an outcome and finishes the match, if it has not finished already.
+   *
+   * <p>Idempotent by design: two conditions can become true in the same instant — a point that
+   * crosses the threshold as the clock expires — and the first one to arrive is the one that
+   * happened. A later call changes nothing, which is what lets the evaluator run after every event
+   * without guarding each call site.
+   */
+  public void applyOutcome(MatchOutcome outcome) {
+    if (gameState == GameState.FINISHED) {
+      return;
+    }
+    if (outcome.winner() != null) {
+      requireFields(outcome.winner());
+    }
+    this.winner = outcome.winner();
+    this.endReason = outcome.reason();
+    this.decidedBy = outcome.decidedBy();
+    this.gameState = GameState.FINISHED;
+    // The clock is read before startTime is cleared: getTimer() rebuilds from that field, so
+    // clearing it first would hand back a timer that never started and report the match's full
+    // remaining time, making an early finish look like one that ran its distance.
+    this.remainingTime = getTimer().stopAndReport();
+    this.startTime = null;
+  }
+
+  public Optional<MatchEndReason> getEndReason() {
+    return Optional.ofNullable(endReason);
+  }
+
+  public Optional<String> getDecidedBy() {
+    return Optional.ofNullable(decidedBy);
+  }
+
+  /** The outcome as it currently stands, or empty while the match is undecided. */
+  public Optional<MatchOutcome> outcome() {
+    return endReason == null
+        ? Optional.empty()
+        : Optional.of(new MatchOutcome(winner, endReason, decidedBy == null ? "" : decidedBy));
+  }
+
+  public Optional<RefereeOverride> getRefereeOverride() {
+    return Optional.ofNullable(refereeOverride);
+  }
+
+  /**
+   * Records a referee's override of the result.
+   *
+   * <p>Sets the state directly rather than going through {@link #applyOutcome}, because an override
+   * applies to a match the rules engine may already have finished — that is its whole purpose. What
+   * the engine had decided is preserved inside the override record.
+   */
+  public void applyOverride(RefereeOverride override) {
+    if (override.winner() != null) {
+      requireFields(override.winner());
+    }
+    this.refereeOverride = override;
+    this.winner = override.winner();
+    this.endReason = MatchEndReason.REFEREE_OVERRIDE;
+    this.decidedBy = "RefereeOverride";
+    if (gameState != GameState.FINISHED) {
+      this.gameState = GameState.FINISHED;
+      // Read the clock before clearing startTime, for the reason applyOutcome states.
+      this.remainingTime = getTimer().stopAndReport();
+      this.startTime = null;
+    }
+  }
+
+  /** Whether the rules engine may still set this match's result. */
+  public boolean isDecidedByReferee() {
+    return refereeOverride != null;
+  }
+
+  public List<ClockAdjustment> getClockAdjustments() {
+    return List.copyOf(clockAdjustments);
+  }
+
+  /**
+   * Adds time to the clock and records that it happened.
+   *
+   * <p>Delegates the arithmetic to the timer, then copies the result back into the persisted fields
+   * — the timer is rebuilt from those on every load, so a change kept only in the timer object
+   * would vanish on the next read.
+   */
+  public void addTime(ClockAdjustment adjustment) {
+    GameTimer clock = getTimer();
+    clock.add(adjustment.added());
+    this.remainingTime = clock.getRemainingTime();
+    if (clock.isRunning()) {
+      this.startTime = clock.startedAt();
+    }
+    this.clockAdjustments.add(adjustment);
   }
 
   public String getId() {

--- a/src/main/java/com/management/models/MatchOutcome.java
+++ b/src/main/java/com/management/models/MatchOutcome.java
@@ -1,0 +1,23 @@
+package com.management.models;
+
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The result of a match: who won, why the match ended, and which rule decided it.
+ *
+ * <p>A colour and an enum, never a sentence — the client renders the wording. {@code winner} is
+ * {@code null} for a genuine draw, which is a real outcome when the clock expires with level scores
+ * and neither fighter has SENSHU.
+ *
+ * @param winner the winning colour, or {@code null} for a draw
+ * @param reason why the match ended
+ * @param decidedBy the name of the rule that produced this winner, for audit and display
+ */
+public record MatchOutcome(@Nullable PlayerColor winner, MatchEndReason reason, String decidedBy) {
+
+  public static MatchOutcome draw(MatchEndReason reason, String decidedBy) {
+    return new MatchOutcome(null, reason, decidedBy);
+  }
+}

--- a/src/main/java/com/management/models/Player.java
+++ b/src/main/java/com/management/models/Player.java
@@ -1,6 +1,8 @@
 package com.management.models;
 
+import com.management.enums.FoulTypes;
 import com.management.enums.PointsType;
+import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
@@ -24,6 +26,9 @@ public class Player {
   private String name;
   private Points points;
   private Foul fouls;
+
+  /** Set by a referee's SHIKKAKU or explicit disqualification, never derived from the count. */
+  private boolean disqualified;
 
   public Player() {}
 
@@ -86,6 +91,20 @@ public class Player {
 
   public void removeFoul() {
     this.fouls.removeFoul();
+  }
+
+  /** The penalty stage this fighter is at, derived from the foul count. Empty when unpenalised. */
+  public Optional<FoulTypes> foulStage() {
+    return FoulTypes.forCount(fouls.getNumOfFouls());
+  }
+
+  public boolean isDisqualified() {
+    return disqualified;
+  }
+
+  /** Puts the fighter out of the match. Irreversible: a disqualification is not un-issued. */
+  public void disqualify() {
+    this.disqualified = true;
   }
 
   public long getVersion() {

--- a/src/main/java/com/management/models/RefereeOverride.java
+++ b/src/main/java/com/management/models/RefereeOverride.java
@@ -1,0 +1,28 @@
+package com.management.models;
+
+import com.management.enums.PlayerColor;
+import java.time.LocalDateTime;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A referee's decision to set the result themselves, and the record of why.
+ *
+ * <p>An override is an exception to the rules applied by a human in a contested setting, so the
+ * reason is the decision's justification and is required. The outcome the rules engine had reached
+ * is kept alongside it: replacing it would destroy the only evidence of what the system thought,
+ * which is exactly what a dispute asks about.
+ *
+ * @param winner the colour the referee declared, or {@code null} for a declared draw
+ * @param reason why the referee overrode the result; never blank
+ * @param decidedBy who decided — a name supplied by the caller today, replaced by an authenticated
+ *     identity when the security epic lands (#81)
+ * @param decidedAt when the override was applied
+ * @param supersededOutcome what the rules engine had determined, or {@code null} if it had not
+ *     decided anything yet
+ */
+public record RefereeOverride(
+    @Nullable PlayerColor winner,
+    String reason,
+    String decidedBy,
+    LocalDateTime decidedAt,
+    @Nullable MatchOutcome supersededOutcome) {}

--- a/src/main/java/com/management/rules/MatchEndCondition.java
+++ b/src/main/java/com/management/rules/MatchEndCondition.java
@@ -1,0 +1,31 @@
+package com.management.rules;
+
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import java.util.Optional;
+
+/**
+ * One reason a match might be over, evaluated on its own.
+ *
+ * <p>Each condition is a separate bean, discovered by the container and collected into a list, so a
+ * new rule — a per-championship variation, a rulebook revision — arrives as a new class and changes
+ * none of the existing ones. That is the extensibility constraint epic #68 carries throughout, and
+ * it mirrors how {@code PointsType} already attaches a strategy per constant.
+ *
+ * <p>Implementations must be cheap and free of side effects: this runs after every point and every
+ * foul, and returning a reason must not itself end anything. Ending is the caller's job, so that
+ * ordering, idempotency and persistence are decided in one place.
+ *
+ * <p><strong>Every implementation declares an {@code @Order}</strong>, because more than one can be
+ * true at the same instant — a fighter at the foul limit is also disqualified once the stage
+ * escalates that far, and a point can cross the winning score on an already-expired clock. The
+ * first to answer supplies the recorded {@code endReason} <em>and</em> the reason handed to the
+ * winner rules, so leaving it to bean-discovery order would let the classpath decide what the
+ * result says. The declared order is most-specific first: disqualification (10), foul limit (20),
+ * points (30), time expiry (40).
+ */
+public interface MatchEndCondition {
+
+  /** The reason this condition ends the match, or empty when it does not apply. */
+  Optional<MatchEndReason> evaluate(GameWithFighters match);
+}

--- a/src/main/java/com/management/rules/MatchOutcomeEvaluator.java
+++ b/src/main/java/com/management/rules/MatchOutcomeEvaluator.java
@@ -1,0 +1,82 @@
+package com.management.rules;
+
+import com.management.enums.GameState;
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * The rules engine: decides whether a match is over, and if so who won.
+ *
+ * <p>This is the component referred to elsewhere as the Game Orchestrator. It holds no state and
+ * writes nothing — it answers a question, and {@code KumiteGameService} applies and persists the
+ * answer. Keeping the decision separate from the write is what lets it be exercised as a plain unit
+ * test with no container and no database, and what keeps ordering and persistence decided in one
+ * place rather than in each rule.
+ *
+ * <p><strong>Both lists are injected, not constructed.</strong> The container supplies every {@link
+ * MatchEndCondition} and every {@link WinnerRule} it finds, the latter sorted by {@code @Order}.
+ * Adding a rule is adding a class; no existing file changes, which is the extensibility constraint
+ * epic #68 sets out.
+ */
+@Component
+public class MatchOutcomeEvaluator {
+
+  private static final Logger log = LoggerFactory.getLogger(MatchOutcomeEvaluator.class);
+
+  private final List<MatchEndCondition> endConditions;
+  private final List<WinnerRule> winnerRules;
+
+  public MatchOutcomeEvaluator(
+      List<MatchEndCondition> endConditions, List<WinnerRule> winnerRules) {
+    this.endConditions = List.copyOf(endConditions);
+    this.winnerRules = List.copyOf(winnerRules);
+  }
+
+  /**
+   * The outcome this match has reached, or empty if it is still being fought.
+   *
+   * <p>A match that has already finished, or that a referee has decided themselves, returns empty:
+   * the first answer stands, and re-evaluating must never rewrite a recorded result.
+   */
+  public Optional<MatchOutcome> evaluate(GameWithFighters match) {
+    if (match.game().getGameState() == GameState.FINISHED || match.game().isDecidedByReferee()) {
+      return Optional.empty();
+    }
+    return firstTriggeredCondition(match).map(reason -> decideWinner(match, reason));
+  }
+
+  /**
+   * Who won, given that the match is over for the stated reason.
+   *
+   * <p>Separate from the ending decision because the two are asked separately: a referee ending a
+   * match by KIKEN knows the reason and needs only the winner.
+   */
+  public MatchOutcome decideWinner(GameWithFighters match, MatchEndReason reason) {
+    return winnerRules.stream()
+        .map(rule -> rule.decide(match, reason))
+        .flatMap(Optional::stream)
+        .findFirst()
+        .orElseGet(() -> MatchOutcome.draw(reason, "NoRuleApplied"));
+  }
+
+  private Optional<MatchEndReason> firstTriggeredCondition(GameWithFighters match) {
+    for (MatchEndCondition condition : endConditions) {
+      Optional<MatchEndReason> reason = condition.evaluate(match);
+      if (reason.isPresent()) {
+        log.debug(
+            "Match {} ends: {} ({})",
+            match.game().getId(),
+            reason.get(),
+            condition.getClass().getSimpleName());
+        return reason;
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/com/management/rules/WinnerRule.java
+++ b/src/main/java/com/management/rules/WinnerRule.java
@@ -1,0 +1,22 @@
+package com.management.rules;
+
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import java.util.Optional;
+
+/**
+ * One way a winner can be decided, evaluated in priority order until one answers.
+ *
+ * <p>Ordered with Spring's {@code @Order}: the container sorts the injected list, so priority is
+ * declared on the rule rather than encoded in a chain of {@code if} statements someone has to
+ * re-read to change. A new rule is a new bean with an order value.
+ *
+ * <p>A rule that does not apply returns empty rather than a null winner — "no rule applied" and
+ * "this rule says nobody won" are different answers, and only the second ends the search.
+ */
+public interface WinnerRule {
+
+  /** The outcome this rule decides, or empty when it has nothing to say about this match. */
+  Optional<MatchOutcome> decide(GameWithFighters match, MatchEndReason reason);
+}

--- a/src/main/java/com/management/rules/conditions/DisqualificationCondition.java
+++ b/src/main/java/com/management/rules/conditions/DisqualificationCondition.java
@@ -1,0 +1,28 @@
+package com.management.rules.conditions;
+
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.models.Player;
+import com.management.rules.MatchEndCondition;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * A fighter is out of the match.
+ *
+ * <p>Disqualification is issued by a referee rather than detected, but it still needs a condition:
+ * the flag is set on the fighter, and this is what turns that into the match ending. Keeping the
+ * two separate means the same code path ends the match however the flag came to be set.
+ */
+@Component
+@Order(10)
+public class DisqualificationCondition implements MatchEndCondition {
+
+  @Override
+  public Optional<MatchEndReason> evaluate(GameWithFighters match) {
+    return match.fighters().values().stream().anyMatch(Player::isDisqualified)
+        ? Optional.of(MatchEndReason.DISQUALIFICATION)
+        : Optional.empty();
+  }
+}

--- a/src/main/java/com/management/rules/conditions/FoulLimitCondition.java
+++ b/src/main/java/com/management/rules/conditions/FoulLimitCondition.java
@@ -1,0 +1,30 @@
+package com.management.rules.conditions;
+
+import com.management.config.GameProperties;
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.rules.MatchEndCondition;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/** A fighter accumulated the configured number of fouls. */
+@Component
+@Order(20)
+public class FoulLimitCondition implements MatchEndCondition {
+
+  private final GameProperties gameProperties;
+
+  public FoulLimitCondition(GameProperties gameProperties) {
+    this.gameProperties = gameProperties;
+  }
+
+  @Override
+  public Optional<MatchEndReason> evaluate(GameWithFighters match) {
+    boolean reached =
+        match.fighters().values().stream()
+            .anyMatch(
+                fighter -> fighter.getFouls().getNumOfFouls() >= gameProperties.foulsEndingMatch());
+    return reached ? Optional.of(MatchEndReason.FOUL_LIMIT) : Optional.empty();
+  }
+}

--- a/src/main/java/com/management/rules/conditions/PointsThresholdCondition.java
+++ b/src/main/java/com/management/rules/conditions/PointsThresholdCondition.java
@@ -1,0 +1,38 @@
+package com.management.rules.conditions;
+
+import com.management.config.GameProperties;
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.models.Player;
+import com.management.rules.MatchEndCondition;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * A fighter crossed the winning score.
+ *
+ * <p>Crossing, not reaching exactly: a fighter on 7 who lands an IPPON finishes on 10, and the
+ * score is never clamped to the threshold — the number is a trigger, and clamping would destroy the
+ * margin the result is reported with.
+ */
+@Component
+@Order(30)
+public class PointsThresholdCondition implements MatchEndCondition {
+
+  private final GameProperties gameProperties;
+
+  public PointsThresholdCondition(GameProperties gameProperties) {
+    this.gameProperties = gameProperties;
+  }
+
+  @Override
+  public Optional<MatchEndReason> evaluate(GameWithFighters match) {
+    boolean crossed = match.fighters().values().stream().anyMatch(this::hasCrossedThreshold);
+    return crossed ? Optional.of(MatchEndReason.POINTS_THRESHOLD) : Optional.empty();
+  }
+
+  private boolean hasCrossedThreshold(Player fighter) {
+    return fighter.getPoints().getNumOfPoints() >= gameProperties.winningPoints();
+  }
+}

--- a/src/main/java/com/management/rules/conditions/TimeExpiredCondition.java
+++ b/src/main/java/com/management/rules/conditions/TimeExpiredCondition.java
@@ -1,0 +1,37 @@
+package com.management.rules.conditions;
+
+import com.management.enums.GameState;
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.rules.MatchEndCondition;
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * The clock reached zero.
+ *
+ * <p><strong>Observed, not pushed.</strong> Nothing wakes up when the clock hits zero — the timer
+ * is derived from stored values rather than running as a scheduled task — so expiry is noticed the
+ * next time something asks, which is after the next point or foul. A match left untouched past its
+ * duration therefore stays open until someone interacts with it. Closing that gap needs the clock
+ * to emit events, which is the timer work's job, not this condition's.
+ *
+ * <p>Only a running match expires: a paused clock is not counting, and a queued one has not
+ * started.
+ */
+@Component
+@Order(40)
+public class TimeExpiredCondition implements MatchEndCondition {
+
+  @Override
+  public Optional<MatchEndReason> evaluate(GameWithFighters match) {
+    if (match.game().getGameState() != GameState.RUNNING) {
+      return Optional.empty();
+    }
+    return match.game().getTimer().getRemainingTime().equals(Duration.ZERO)
+        ? Optional.of(MatchEndReason.TIME_EXPIRED)
+        : Optional.empty();
+  }
+}

--- a/src/main/java/com/management/rules/winners/DisqualificationWinnerRule.java
+++ b/src/main/java/com/management/rules/winners/DisqualificationWinnerRule.java
@@ -1,0 +1,39 @@
+package com.management.rules.winners;
+
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import com.management.rules.WinnerRule;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * A disqualified fighter loses, whatever the score said.
+ *
+ * <p>Highest priority: a fighter who is out cannot win on points they had already scored, so this
+ * has to answer before any score-based rule gets a chance to.
+ */
+@Component
+@Order(10)
+public class DisqualificationWinnerRule implements WinnerRule {
+
+  @Override
+  public Optional<MatchOutcome> decide(GameWithFighters match, MatchEndReason reason) {
+    Map<PlayerColor, com.management.models.Player> fighters = match.fighters();
+    return fighters.entrySet().stream()
+        .filter(entry -> entry.getValue().isDisqualified())
+        .findFirst()
+        .map(entry -> new MatchOutcome(opponentOf(entry.getKey()), reason, ruleName()));
+  }
+
+  private static PlayerColor opponentOf(PlayerColor color) {
+    return color == PlayerColor.RED ? PlayerColor.BLUE : PlayerColor.RED;
+  }
+
+  private static String ruleName() {
+    return DisqualificationWinnerRule.class.getSimpleName();
+  }
+}

--- a/src/main/java/com/management/rules/winners/DrawWinnerRule.java
+++ b/src/main/java/com/management/rules/winners/DrawWinnerRule.java
@@ -1,0 +1,27 @@
+package com.management.rules.winners;
+
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import com.management.rules.WinnerRule;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Nobody won: level scores, and neither fighter ever scored, so there is no SENSHU to break the
+ * tie.
+ *
+ * <p>Lowest priority, and it always answers — a match that ends must record a result, and "drawn"
+ * is a real one rather than the absence of one. Having it as a rule rather than a fallback branch
+ * keeps the search total: the evaluator never has to handle "no rule applied".
+ */
+@Component
+@Order(Integer.MAX_VALUE)
+public class DrawWinnerRule implements WinnerRule {
+
+  @Override
+  public Optional<MatchOutcome> decide(GameWithFighters match, MatchEndReason reason) {
+    return Optional.of(MatchOutcome.draw(reason, DrawWinnerRule.class.getSimpleName()));
+  }
+}

--- a/src/main/java/com/management/rules/winners/FoulLimitWinnerRule.java
+++ b/src/main/java/com/management/rules/winners/FoulLimitWinnerRule.java
@@ -1,0 +1,55 @@
+package com.management.rules.winners;
+
+import com.management.config.GameProperties;
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import com.management.models.Player;
+import com.management.rules.WinnerRule;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * A fighter who accumulates the foul limit loses the match.
+ *
+ * <p>Without this rule the score decided a foul-limit ending, which let a fighter <em>win by
+ * fouling</em>: leading 3–0 and one foul short of the limit, committing that foul ended the match
+ * with them still ahead. A penalty that benefits the fighter it penalises is not a penalty, and it
+ * rewards exactly the behaviour the foul count exists to suppress.
+ *
+ * <p>Ranked below disqualification and above the score, mirroring the ending conditions: being put
+ * out is more specific than fouling out, and both outrank whatever the scoreboard says.
+ */
+@Component
+@Order(15)
+public class FoulLimitWinnerRule implements WinnerRule {
+
+  private final GameProperties gameProperties;
+
+  public FoulLimitWinnerRule(GameProperties gameProperties) {
+    this.gameProperties = gameProperties;
+  }
+
+  @Override
+  public Optional<MatchOutcome> decide(GameWithFighters match, MatchEndReason reason) {
+    Map<PlayerColor, Player> fighters = match.fighters();
+    return fighters.entrySet().stream()
+        .filter(entry -> hasFouledOut(entry.getValue()))
+        .findFirst()
+        .map(
+            entry ->
+                new MatchOutcome(
+                    opponentOf(entry.getKey()), reason, FoulLimitWinnerRule.class.getSimpleName()));
+  }
+
+  private boolean hasFouledOut(Player fighter) {
+    return fighter.getFouls().getNumOfFouls() >= gameProperties.foulsEndingMatch();
+  }
+
+  private static PlayerColor opponentOf(PlayerColor color) {
+    return color == PlayerColor.RED ? PlayerColor.BLUE : PlayerColor.RED;
+  }
+}

--- a/src/main/java/com/management/rules/winners/HighestScoreWinnerRule.java
+++ b/src/main/java/com/management/rules/winners/HighestScoreWinnerRule.java
@@ -1,0 +1,42 @@
+package com.management.rules.winners;
+
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import com.management.models.Player;
+import com.management.rules.WinnerRule;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * The higher score wins.
+ *
+ * <p>Covers both the threshold crossing and an ordinary decision at time expiry: whoever crossed
+ * the winning score necessarily has the higher score, so one rule serves both and there is no
+ * second place for the comparison to drift. Level scores are not this rule's business — it declines
+ * and SENSHU answers next.
+ */
+@Component
+@Order(20)
+public class HighestScoreWinnerRule implements WinnerRule {
+
+  @Override
+  public Optional<MatchOutcome> decide(GameWithFighters match, MatchEndReason reason) {
+    int red = pointsOf(match, PlayerColor.RED);
+    int blue = pointsOf(match, PlayerColor.BLUE);
+
+    if (red == blue) {
+      return Optional.empty();
+    }
+    PlayerColor leader = red > blue ? PlayerColor.RED : PlayerColor.BLUE;
+    return Optional.of(
+        new MatchOutcome(leader, reason, HighestScoreWinnerRule.class.getSimpleName()));
+  }
+
+  private static int pointsOf(GameWithFighters match, PlayerColor color) {
+    Player fighter = match.fighters().get(color);
+    return fighter == null ? 0 : fighter.getPoints().getNumOfPoints();
+  }
+}

--- a/src/main/java/com/management/rules/winners/SenshuWinnerRule.java
+++ b/src/main/java/com/management/rules/winners/SenshuWinnerRule.java
@@ -1,0 +1,29 @@
+package com.management.rules.winners;
+
+import com.management.enums.MatchEndReason;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import com.management.rules.WinnerRule;
+import java.util.Optional;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Level scores are decided by SENSHU — whoever scored first.
+ *
+ * <p>Runs after the score comparison, because it only applies when the scores are level. The value
+ * it reads is captured at the moment of the first score; nothing here can reconstruct it, which is
+ * why the capture happens during scoring rather than at the end.
+ */
+@Component
+@Order(30)
+public class SenshuWinnerRule implements WinnerRule {
+
+  @Override
+  public Optional<MatchOutcome> decide(GameWithFighters match, MatchEndReason reason) {
+    return match
+        .game()
+        .getSenshu()
+        .map(first -> new MatchOutcome(first, reason, SenshuWinnerRule.class.getSimpleName()));
+  }
+}

--- a/src/main/java/com/management/services/KumiteGameService.java
+++ b/src/main/java/com/management/services/KumiteGameService.java
@@ -1,21 +1,29 @@
 package com.management.services;
 
 import com.management.config.GameProperties;
+import com.management.dto.ClockAdjustmentRequest;
 import com.management.dto.KumiteGameRequestDTO;
 import com.management.dto.PlayerDTO;
 import com.management.dto.PlayerRequestDTO;
+import com.management.dto.WinnerOverrideRequest;
+import com.management.enums.FoulTypes;
 import com.management.enums.GameState;
+import com.management.enums.MatchEndReason;
 import com.management.enums.PlayerColor;
 import com.management.enums.PointsType;
 import com.management.exceptions.GameNotFoundException;
 import com.management.exceptions.IllegalStateTransitionException;
 import com.management.exceptions.InvalidGameRequestException;
 import com.management.exceptions.PlayerNotFoundException;
+import com.management.models.ClockAdjustment;
 import com.management.models.GameWithFighters;
 import com.management.models.KumiteGame;
+import com.management.models.MatchOutcome;
 import com.management.models.Player;
 import com.management.models.Referee;
+import com.management.models.RefereeOverride;
 import com.management.repositories.KumiteGameRepository;
+import com.management.rules.MatchOutcomeEvaluator;
 import com.management.util.KumiteGameManagementUtils;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -25,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,14 +58,20 @@ public class KumiteGameService {
   private final KumiteGameRepository kumiteGameRepository;
   private final GameProperties gameProperties;
   private final PlayerService playerService;
+  private final MatchOutcomeEvaluator outcomeEvaluator;
+  private final MatchStateWriter matchStateWriter;
 
   public KumiteGameService(
       KumiteGameRepository kumiteGameRepository,
       GameProperties gameProperties,
-      PlayerService playerService) {
+      PlayerService playerService,
+      MatchOutcomeEvaluator outcomeEvaluator,
+      MatchStateWriter matchStateWriter) {
     this.kumiteGameRepository = kumiteGameRepository;
     this.gameProperties = gameProperties;
     this.playerService = playerService;
+    this.outcomeEvaluator = outcomeEvaluator;
+    this.matchStateWriter = matchStateWriter;
   }
 
   /**
@@ -121,39 +136,301 @@ public class KumiteGameService {
 
   public GameWithFighters addPoint(String gameId, String color, String pointType) {
     KumiteGame kumiteGame = getKumiteGame(gameId);
+    requireOpen(kumiteGame, "scored against");
+    requireClockNotExpired(kumiteGame, "scored against");
     PointsType point = KumiteGameManagementUtils.mapPointToPointType(pointType);
     PlayerColor scoringColour = KumiteGameManagementUtils.mapPlayerColor(color);
     Player scored = playerService.addPoint(fighterId(kumiteGame, scoringColour), point);
-    return withFighters(kumiteGame, scoringColour, scored);
+
+    boolean firstScore =
+        kumiteGame.getSenshu().isEmpty() && scored.getPoints().getNumOfPoints() > 0;
+    if (firstScore) {
+      kumiteGame.recordFirstScorer(scoringColour);
+    }
+
+    return settle(
+        withFighters(kumiteGame, scoringColour, scored), firstScore ? scoringColour : null);
   }
 
+  /**
+   * Takes a point back, and takes SENSHU with it when the fighter is left with nothing.
+   *
+   * <p>SENSHU is "the first to score", so a fighter whose score has been corrected back to zero
+   * cannot hold it: leaving it set let a mistakenly-awarded point that was then removed decide a
+   * level match at time expiry, in favour of a fighter who never actually scored first. Clearing it
+   * is enough — SENSHU only breaks a tie, and a fighter on zero against an opponent with points is
+   * not in one.
+   */
   public GameWithFighters removePoint(String gameId, String color, String pointType) {
     KumiteGame kumiteGame = getKumiteGame(gameId);
+    requireOpen(kumiteGame, "scored against");
     PointsType point = KumiteGameManagementUtils.mapPointToPointType(pointType);
     PlayerColor scoringColour = KumiteGameManagementUtils.mapPlayerColor(color);
     Player scored = playerService.removePoint(fighterId(kumiteGame, scoringColour), point);
-    return withFighters(kumiteGame, scoringColour, scored);
+
+    boolean senshuLapsed =
+        kumiteGame.getSenshu().filter(scoringColour::equals).isPresent()
+            && scored.getPoints().getNumOfPoints() == 0;
+
+    return settleWith(
+        withFighters(kumiteGame, scoringColour, scored),
+        game -> {
+          if (senshuLapsed) {
+            game.clearFirstScorer();
+          }
+        },
+        senshuLapsed);
   }
 
+  /**
+   * Records a foul and applies whatever its new penalty stage carries.
+   *
+   * <p>The stage is derived from the count, so this only has to act on the consequence: a stage
+   * that awards points hands them to the opponent through the ordinary scoring path — the same
+   * versioned, retried write a referee's award goes through — and a disqualifying stage puts the
+   * fighter out. Doing it any other way would give the score a second route into the database.
+   */
   public GameWithFighters addFoul(String gameId, String color) {
     KumiteGame kumiteGame = getKumiteGame(gameId);
+    requireOpen(kumiteGame, "penalised");
     PlayerColor penalisedColour = KumiteGameManagementUtils.mapPlayerColor(color);
     Player penalised = playerService.addFoul(fighterId(kumiteGame, penalisedColour));
-    return withFighters(kumiteGame, penalisedColour, penalised);
+
+    Optional<FoulTypes> stage = penalised.foulStage();
+    PlayerColor opponentColour = opponentOf(penalisedColour);
+    PlayerColor firstScorer =
+        stage
+            .flatMap(FoulTypes::opponentAward)
+            .map(
+                award -> {
+                  boolean unclaimed = kumiteGame.getSenshu().isEmpty();
+                  playerService.addPoint(fighterId(kumiteGame, opponentColour), award);
+                  return unclaimed ? opponentColour : null;
+                })
+            .orElse(null);
+    if (stage.filter(FoulTypes::isDisqualifying).isPresent()) {
+      penalised = playerService.disqualify(penalised.getId());
+    }
+
+    return settle(withFighters(kumiteGame, penalisedColour, penalised), firstScorer);
   }
 
+  /**
+   * Removes a foul, provided its stage carried no consequence.
+   *
+   * <p>Walking a consequence backwards is not the same operation as walking a count backwards: a
+   * point handed to the opponent has since become part of their score, which they may have added
+   * to, and a disqualification has already ended the match. Rather than guess how far back to
+   * unwind, a reversal that would have to undo a consequence is refused — the referee's route out
+   * is an override, which records why. Reversing a plain warning is unrestricted.
+   */
   public GameWithFighters removeFoul(String gameId, String color) {
     KumiteGame kumiteGame = getKumiteGame(gameId);
+    requireOpen(kumiteGame, "penalised");
     PlayerColor penalisedColour = KumiteGameManagementUtils.mapPlayerColor(color);
-    Player penalised = playerService.removeFoul(fighterId(kumiteGame, penalisedColour));
-    return withFighters(kumiteGame, penalisedColour, penalised);
+    String penalisedId = fighterId(kumiteGame, penalisedColour);
+
+    Player current = playerService.getPlayer(penalisedId);
+    current
+        .foulStage()
+        .filter(stage -> stage.opponentAward().isPresent() || stage.isDisqualifying())
+        .ifPresent(
+            stage -> {
+              throw new IllegalStateTransitionException(
+                  "Fighter "
+                      + penalisedColour
+                      + " is at "
+                      + stage
+                      + ", which already had a consequence. Removing that foul would have to undo"
+                      + " it; use a referee override instead.");
+            });
+
+    Player penalised = playerService.removeFoul(penalisedId);
+    return settle(withFighters(kumiteGame, penalisedColour, penalised), null);
   }
 
+  /** Puts a fighter out of the match, which the rules engine turns into a win for the opponent. */
+  public GameWithFighters disqualify(String gameId, String color) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    requireOpen(kumiteGame, "disqualified from");
+    PlayerColor colour = KumiteGameManagementUtils.mapPlayerColor(color);
+    Player disqualified = playerService.disqualify(fighterId(kumiteGame, colour));
+    return settle(withFighters(kumiteGame, colour, disqualified), null);
+  }
+
+  /**
+   * Records a forfeit — KIKEN — against a fighter who did not appear or withdrew.
+   *
+   * <p>Operator-initiated and immediate: no condition can detect an absence, so the reason is
+   * supplied rather than evaluated, and the opponent wins on the spot.
+   */
+  public GameWithFighters forfeit(String gameId, String color) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    requireOpen(kumiteGame, "forfeited");
+    PlayerColor forfeitingColour = KumiteGameManagementUtils.mapPlayerColor(color);
+    fighterId(kumiteGame, forfeitingColour);
+
+    GameWithFighters match = withFighters(kumiteGame);
+    kumiteGame.applyOutcome(
+        new MatchOutcome(opponentOf(forfeitingColour), MatchEndReason.KIKEN, "Kiken"));
+    return new GameWithFighters(saveGame(kumiteGame), match.fighters());
+  }
+
+  /**
+   * Replaces the result with a referee's decision, and records why.
+   *
+   * <p>Permitted on a match that has started, including one the engine has already finished —
+   * correcting a decided result is the main thing an override is for. A queued match is refused:
+   * nothing has happened yet to overrule. Whatever the engine had determined is kept inside the
+   * override record rather than overwritten.
+   *
+   * <p><strong>An override of an override keeps the engine's original result.</strong> Reading the
+   * current outcome blindly would record the previous <em>override</em> as the superseded one,
+   * because the first override has already stamped itself onto those fields — so the one thing the
+   * record exists to preserve, what the system itself concluded, would be lost on the second
+   * correction.
+   */
+  public GameWithFighters overrideWinner(String gameId, WinnerOverrideRequest request) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    if (kumiteGame.getGameState() == GameState.QUEUED) {
+      throw new IllegalStateTransitionException(
+          "Match " + gameId + " has not started, so there is no result to override.");
+    }
+    PlayerColor declared =
+        request.winner() == null
+            ? null
+            : KumiteGameManagementUtils.mapPlayerColor(request.winner());
+
+    MatchOutcome engineOutcome =
+        kumiteGame
+            .getRefereeOverride()
+            .map(RefereeOverride::supersededOutcome)
+            .orElseGet(() -> kumiteGame.outcome().orElse(null));
+
+    kumiteGame.applyOverride(
+        new RefereeOverride(
+            declared, request.reason(), request.decidedBy(), LocalDateTime.now(), engineOutcome));
+    return withFighters(saveGame(kumiteGame));
+  }
+
+  /**
+   * Adds time to the clock to compensate for a stop that came late.
+   *
+   * <p>Refused on a finished match: its clock is history. Allowed while running and while paused —
+   * the timer handles the elapsed-time arithmetic that makes the running case correct.
+   */
+  public GameWithFighters addTime(String gameId, ClockAdjustmentRequest request) {
+    KumiteGame kumiteGame = getKumiteGame(gameId);
+    if (kumiteGame.getGameState() == GameState.FINISHED) {
+      throw new IllegalStateTransitionException(
+          "Match " + gameId + " has finished; its clock cannot be extended.");
+    }
+    Duration extra = Duration.ofSeconds(request.seconds());
+    if (!gameProperties.clockIncrements().contains(extra)) {
+      throw new InvalidGameRequestException(
+          "Time may be added in increments of "
+              + gameProperties.clockIncrements()
+              + ", but "
+              + extra
+              + " was requested.");
+    }
+
+    kumiteGame.addTime(new ClockAdjustment(extra, LocalDateTime.now(), request.addedBy()));
+    return withFighters(saveGame(kumiteGame));
+  }
+
+  /**
+   * The manual winner path, kept as the rules engine's escape hatch until #73's override replaced
+   * it as the documented route.
+   */
   public GameWithFighters updateKumiteGameWinner(String gameId, String color) {
     KumiteGame kumiteGame = getKumiteGame(gameId);
     PlayerColor playerColor = KumiteGameManagementUtils.mapPlayerColor(color);
     kumiteGame.updateWinner(playerColor);
     return withFighters(saveGame(kumiteGame));
+  }
+
+  /**
+   * Asks the rules engine whether the match is over, and records the answer if it is — along with
+   * the first scorer, when this event produced it.
+   *
+   * <p>Both facts are write-once, so the write goes through {@link MatchStateWriter}, which
+   * re-reads and re-applies on a conflict. Nothing is written when neither fact changed, which
+   * keeps an ordinary mid-match point to a single document write.
+   */
+  private GameWithFighters settle(GameWithFighters match, @Nullable PlayerColor firstScorer) {
+    return settleWith(
+        match,
+        game -> {
+          if (firstScorer != null) {
+            game.recordFirstScorer(firstScorer);
+          }
+        },
+        firstScorer != null);
+  }
+
+  /**
+   * The general form: apply a write-once change to the match, then whatever the engine decided.
+   *
+   * @param alsoChanged whether {@code change} actually alters anything, so an event that neither
+   *     ends the match nor touches match-level state still costs no document write
+   */
+  private GameWithFighters settleWith(
+      GameWithFighters match, Consumer<KumiteGame> change, boolean alsoChanged) {
+    Optional<MatchOutcome> outcome = outcomeEvaluator.evaluate(match);
+    if (outcome.isEmpty() && !alsoChanged) {
+      return match;
+    }
+
+    KumiteGame saved =
+        matchStateWriter.applyAndSave(
+            match.game().getId(),
+            game -> {
+              change.accept(game);
+              outcome.ifPresent(game::applyOutcome);
+            });
+    return new GameWithFighters(saved, match.fighters());
+  }
+
+  /**
+   * Refuses an operation on a match that has already produced a result.
+   *
+   * <p>Scoring a finished match would move the score while the recorded result stayed put, which is
+   * worse than refusing: the two would disagree with no indication which is authoritative. A
+   * referee who genuinely needs to change a decided match uses an override, which records why.
+   */
+  private static void requireOpen(KumiteGame kumiteGame, String action) {
+    if (kumiteGame.getGameState() == GameState.FINISHED) {
+      throw new IllegalStateTransitionException(
+          "Match " + kumiteGame.getId() + " has finished and cannot be " + action + ".");
+    }
+  }
+
+  /**
+   * Refuses an event that arrives after the clock has already run out, finishing the match first.
+   *
+   * <p>Expiry is noticed rather than pushed, so a match whose time ran out is still {@code RUNNING}
+   * until something asks. Without this, a point landing seconds late was written to the fighter and
+   * only *then* did the evaluator notice the expiry — with the late point already counted, turning
+   * a drawn match into a win. The match is settled here so the ending is recorded at once, and the
+   * event itself is refused.
+   */
+  private void requireClockNotExpired(KumiteGame kumiteGame, String action) {
+    if (kumiteGame.getGameState() != GameState.RUNNING
+        || !kumiteGame.getTimer().getRemainingTime().isZero()) {
+      return;
+    }
+    settle(withFighters(kumiteGame), null);
+    throw new IllegalStateTransitionException(
+        "Match "
+            + kumiteGame.getId()
+            + " ran out of time before this event, so it cannot be "
+            + action
+            + ".");
+  }
+
+  private static PlayerColor opponentOf(PlayerColor color) {
+    return color == PlayerColor.RED ? PlayerColor.BLUE : PlayerColor.RED;
   }
 
   /**

--- a/src/main/java/com/management/services/MatchStateWriter.java
+++ b/src/main/java/com/management/services/MatchStateWriter.java
@@ -1,0 +1,49 @@
+package com.management.services;
+
+import com.management.exceptions.GameNotFoundException;
+import com.management.models.KumiteGame;
+import com.management.repositories.KumiteGameRepository;
+import java.util.function.Consumer;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.resilience.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Applies an idempotent change to a match document, retrying a losing write.
+ *
+ * <p>Recording the first scorer and recording the result are both write-once facts: the second
+ * caller to try either is meant to change nothing. Without a retry they instead collide — the
+ * versioned save loses and the caller gets a 409 for an operation that had already succeeded from
+ * their point of view. Two referees scoring simultaneously on an untouched match hit exactly that,
+ * because both see SENSHU as unclaimed and both try to claim it.
+ *
+ * <p><strong>A separate bean, not a private method.</strong> {@code @Retryable} is applied by a
+ * proxy, so a service calling its own annotated method would bypass it entirely. The change is
+ * re-applied to a freshly read document on every attempt, which is what makes retrying safe: {@code
+ * recordFirstScorer} and {@code applyOutcome} both no-op once the fact is already recorded.
+ */
+@Service
+public class MatchStateWriter {
+
+  private final KumiteGameRepository kumiteGameRepository;
+
+  public MatchStateWriter(KumiteGameRepository kumiteGameRepository) {
+    this.kumiteGameRepository = kumiteGameRepository;
+  }
+
+  @Retryable(
+      includes = OptimisticLockingFailureException.class,
+      maxRetries = 9,
+      delay = 20,
+      jitter = 20,
+      multiplier = 1.5,
+      maxDelay = 200)
+  public KumiteGame applyAndSave(String gameId, Consumer<KumiteGame> change) {
+    KumiteGame fresh =
+        kumiteGameRepository
+            .findById(gameId)
+            .orElseThrow(() -> new GameNotFoundException("Game not found! Game Id: " + gameId));
+    change.accept(fresh);
+    return kumiteGameRepository.save(fresh);
+  }
+}

--- a/src/main/java/com/management/services/PlayerService.java
+++ b/src/main/java/com/management/services/PlayerService.java
@@ -124,4 +124,18 @@ public class PlayerService {
     player.removeFoul();
     return playerRepository.save(player);
   }
+
+  /** Puts a fighter out of the match. Retried like the rest: it is a read-modify-write too. */
+  @Retryable(
+      includes = OptimisticLockingFailureException.class,
+      maxRetries = 9,
+      delay = 20,
+      jitter = 20,
+      multiplier = 1.5,
+      maxDelay = 200)
+  public Player disqualify(String playerId) {
+    Player player = getPlayer(playerId);
+    player.disqualify();
+    return playerRepository.save(player);
+  }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,17 @@
-# Match durations. Bound and validated by com.management.config.GameProperties;
+# The rules a match is run by. Bound and validated by com.management.config.GameProperties;
 # suffixed values arrive as java.time.Duration.
 game.default-duration=120s
 game.optional-durations=90s,180s
+
+# The score a fighter must cross to win. A trigger, not a cap: crossing 8 with an IPPON
+# from 7 finishes the match at 10.
+game.winning-points=8
+
+# Fouls that end the match against the fighter who committed them.
+game.fouls-ending-match=4
+
+# Time a referee may add to compensate for a clock stopped late.
+game.clock-increments=10s,30s
 
 spring.mongodb.host=${MONGO_HOST:localhost}
 spring.mongodb.port=${MONGO_PORT:27017}

--- a/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameControllerSliceTest.java
@@ -193,7 +193,9 @@ class KumiteGameControllerSliceTest extends WebSliceTestBase {
                       "red":  { "id": "red-1",  "name": "Kenji", "points": 3, "fouls": 0 },
                       "blue": { "id": "blue-1", "name": "Sato",  "points": 0, "fouls": 1 },
                       "referees": ["Test Referee"],
-                      "winner": null
+                      "winner": null,
+                      "endReason": null,
+                      "overridden": false
                     }
                     """,
                     JsonCompareMode.STRICT));

--- a/src/test/java/com/management/kumitegametests/KumiteGameCreationTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameCreationTest.java
@@ -19,10 +19,12 @@ import com.management.models.Player;
 import com.management.repositories.KumiteGameRepository;
 import com.management.repositories.PlayerRepository;
 import com.management.services.KumiteGameService;
+import com.management.services.MatchStateWriter;
 import com.management.services.PlayerService;
 import com.management.testsupport.FakeRepositories;
 import com.management.testsupport.InMemoryMongo;
 import com.management.testsupport.TestGameProperties;
+import com.management.testsupport.TestRulesEngine;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,7 +52,11 @@ class KumiteGameCreationTest {
     playerService = new PlayerService(FakeRepositories.players(storage));
     service =
         new KumiteGameService(
-            FakeRepositories.kumiteGames(storage), TestGameProperties.standard(), playerService);
+            FakeRepositories.kumiteGames(storage),
+            TestGameProperties.standard(),
+            playerService,
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
   }
 
   @Test
@@ -95,7 +101,9 @@ class KumiteGameCreationTest {
         new KumiteGameService(
             FakeRepositories.kumiteGames(storage),
             TestGameProperties.standard(),
-            new PlayerService(flakyFighters));
+            new PlayerService(flakyFighters),
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
 
     assertThatThrownBy(
             () ->
@@ -118,9 +126,19 @@ class KumiteGameCreationTest {
   @Test
   void createKumiteGame_withNoDuration_usesTheInjectedDefault() {
     GameProperties fiveMinutes =
-        new GameProperties(Duration.ofMinutes(5), List.of(Duration.ofMinutes(5)));
+        new GameProperties(
+            Duration.ofMinutes(5),
+            List.of(Duration.ofMinutes(5)),
+            TestGameProperties.WINNING_POINTS,
+            TestGameProperties.FOULS_ENDING_MATCH,
+            List.of(Duration.ofSeconds(10)));
     KumiteGameService customised =
-        new KumiteGameService(FakeRepositories.kumiteGames(storage), fiveMinutes, playerService);
+        new KumiteGameService(
+            FakeRepositories.kumiteGames(storage),
+            fiveMinutes,
+            playerService,
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
 
     GameWithFighters created =
         customised.createKumiteGame(
@@ -184,7 +202,12 @@ class KumiteGameCreationTest {
     when(failingRepository.save(any(KumiteGame.class)))
         .thenThrow(new IllegalStateException("simulated write failure"));
     KumiteGameService failingService =
-        new KumiteGameService(failingRepository, TestGameProperties.standard(), playerService);
+        new KumiteGameService(
+            failingRepository,
+            TestGameProperties.standard(),
+            playerService,
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
 
     assertThatThrownBy(
             () ->

--- a/src/test/java/com/management/kumitegametests/KumiteGameReloadTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameReloadTest.java
@@ -7,11 +7,13 @@ import com.management.enums.GameState;
 import com.management.models.KumiteGame;
 import com.management.repositories.KumiteGameRepository;
 import com.management.services.KumiteGameService;
+import com.management.services.MatchStateWriter;
 import com.management.services.PlayerService;
 import com.management.testsupport.FakeRepositories;
 import com.management.testsupport.InMemoryMongo;
 import com.management.testsupport.KumiteGameBuilder;
 import com.management.testsupport.TestGameProperties;
+import com.management.testsupport.TestRulesEngine;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +51,11 @@ class KumiteGameReloadTest {
 
     service =
         new KumiteGameService(
-            repository, TestGameProperties.standard(), Mockito.mock(PlayerService.class));
+            repository,
+            TestGameProperties.standard(),
+            Mockito.mock(PlayerService.class),
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
   }
 
   @Test

--- a/src/test/java/com/management/kumitegametests/KumiteGameStateTransitionTest.java
+++ b/src/test/java/com/management/kumitegametests/KumiteGameStateTransitionTest.java
@@ -8,11 +8,13 @@ import com.management.exceptions.IllegalStateTransitionException;
 import com.management.models.KumiteGame;
 import com.management.repositories.KumiteGameRepository;
 import com.management.services.KumiteGameService;
+import com.management.services.MatchStateWriter;
 import com.management.services.PlayerService;
 import com.management.testsupport.FakeRepositories;
 import com.management.testsupport.InMemoryMongo;
 import com.management.testsupport.KumiteGameBuilder;
 import com.management.testsupport.TestGameProperties;
+import com.management.testsupport.TestRulesEngine;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +40,11 @@ class KumiteGameStateTransitionTest {
 
     service =
         new KumiteGameService(
-            repository, TestGameProperties.standard(), Mockito.mock(PlayerService.class));
+            repository,
+            TestGameProperties.standard(),
+            Mockito.mock(PlayerService.class),
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
   }
 
   @Test

--- a/src/test/java/com/management/kumitegametests/MatchOutcomeServiceTest.java
+++ b/src/test/java/com/management/kumitegametests/MatchOutcomeServiceTest.java
@@ -1,0 +1,364 @@
+package com.management.kumitegametests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.management.dto.ClockAdjustmentRequest;
+import com.management.dto.WinnerOverrideRequest;
+import com.management.enums.GameState;
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import com.management.enums.PointsType;
+import com.management.exceptions.IllegalStateTransitionException;
+import com.management.exceptions.InvalidGameRequestException;
+import com.management.models.GameWithFighters;
+import com.management.models.KumiteGame;
+import com.management.models.Player;
+import com.management.services.KumiteGameService;
+import com.management.services.MatchStateWriter;
+import com.management.services.PlayerService;
+import com.management.testsupport.FakeRepositories;
+import com.management.testsupport.InMemoryMongo;
+import com.management.testsupport.KumiteGameBuilder;
+import com.management.testsupport.PlayerBuilder;
+import com.management.testsupport.TestGameProperties;
+import com.management.testsupport.TestRulesEngine;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The rules engine driven through the service, across a real save-and-reload boundary.
+ *
+ * <p>{@code MatchOutcomeEvaluatorTest} proves the rules decide correctly in isolation. This proves
+ * the service asks them at the right moments, records what they say, and persists it — the wiring
+ * between a scoring call and a finished match, which neither the rule tests nor the slice tests can
+ * see.
+ */
+class MatchOutcomeServiceTest {
+
+  private InMemoryMongo storage;
+  private PlayerService playerService;
+  private KumiteGameService service;
+
+  @BeforeEach
+  void setUp() {
+    storage = new InMemoryMongo();
+    playerService = new PlayerService(FakeRepositories.players(storage));
+    service =
+        new KumiteGameService(
+            FakeRepositories.kumiteGames(storage),
+            TestGameProperties.standard(),
+            playerService,
+            TestRulesEngine.standard(),
+            new MatchStateWriter(FakeRepositories.kumiteGames(storage)));
+  }
+
+  @Test
+  void addPoint_whenTheScoreCrossesTheThreshold_finishesTheMatchWithoutAnyoneEndingIt() {
+    String gameId = runningMatch();
+
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+    GameWithFighters afterThird = service.addPoint(gameId, "RED", PointsType.IPPON.name());
+
+    assertThat(afterThird.game().getGameState()).isEqualTo(GameState.FINISHED);
+    assertThat(afterThird.game().getWinner()).isEqualTo(PlayerColor.RED);
+    assertThat(afterThird.game().getEndReason()).contains(MatchEndReason.POINTS_THRESHOLD);
+
+    KumiteGame stored = storage.findById(KumiteGame.class, gameId).orElseThrow();
+    assertThat(stored.getGameState())
+        .as("the ending is persisted, not just returned")
+        .isEqualTo(GameState.FINISHED);
+    assertThat(stored.getDecidedBy()).contains("HighestScoreWinnerRule");
+  }
+
+  /**
+   * A match that ends early keeps the time that was left on the clock.
+   *
+   * <p>{@code applyOutcome} used to null {@code startTime} before reading the timer, and the timer
+   * rebuilds itself from that field — so it was constructed as a clock that had never started and
+   * reported the full duration. An eight-point finish 30 seconds in was recorded as though it had
+   * run its distance.
+   */
+  @Test
+  void addPoint_endingTheMatchEarly_recordsTheTimeThatWasLeft() {
+    String gameId =
+        storedMatch(
+            match ->
+                match.runningSince(LocalDateTime.now().minusSeconds(30), Duration.ofSeconds(120)));
+
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+    GameWithFighters finished = service.addPoint(gameId, "RED", PointsType.IPPON.name());
+
+    assertThat(finished.game().getGameState()).isEqualTo(GameState.FINISHED);
+    assertThat(finished.game().getRemainingTime())
+        .as("roughly 90s were left when the ninth point landed, not the full 120s")
+        .isBetween(Duration.ofSeconds(85), Duration.ofSeconds(92));
+  }
+
+  @Test
+  void overrideWinner_onRunningMatch_recordsTheTimeThatWasLeft() {
+    String gameId =
+        storedMatch(
+            match ->
+                match.runningSince(LocalDateTime.now().minusSeconds(30), Duration.ofSeconds(120)));
+
+    GameWithFighters overridden =
+        service.overrideWinner(
+            gameId, new WinnerOverrideRequest("RED", "Stopped on the mat", "Head Referee"));
+
+    assertThat(overridden.game().getRemainingTime())
+        .isBetween(Duration.ofSeconds(85), Duration.ofSeconds(92));
+  }
+
+  /**
+   * A point that arrives after the clock ran out must not count.
+   *
+   * <p>Expiry is noticed rather than pushed, so the match is still RUNNING when the late point
+   * arrives. It used to be written to the fighter and only then did the evaluator notice the expiry
+   * — with the late point already in the score, turning a draw into a win.
+   */
+  @Test
+  void addPoint_afterTheClockRanOut_isRefusedAndFinishesTheMatchAsDrawn() {
+    String gameId =
+        storedMatch(
+            match ->
+                match.runningSince(LocalDateTime.now().minusMinutes(5), Duration.ofSeconds(30)));
+
+    assertThatThrownBy(() -> service.addPoint(gameId, "RED", PointsType.IPPON.name()))
+        .isInstanceOf(IllegalStateTransitionException.class)
+        .hasMessageContaining("ran out of time");
+
+    KumiteGame stored = storage.findById(KumiteGame.class, gameId).orElseThrow();
+    assertThat(stored.getGameState()).isEqualTo(GameState.FINISHED);
+    assertThat(stored.getEndReason()).contains(MatchEndReason.TIME_EXPIRED);
+    assertThat(stored.getWinner()).as("the late point did not decide it").isNull();
+  }
+
+  /** A corrected-away point takes SENSHU with it, so it cannot decide a level match later. */
+  @Test
+  void removePoint_takingTheScorerBackToZero_clearsSenshu() {
+    String gameId = runningMatch();
+    service.addPoint(gameId, "RED", PointsType.YUKO.name());
+
+    assertThat(storage.findById(KumiteGame.class, gameId).orElseThrow().getSenshu())
+        .contains(PlayerColor.RED);
+
+    service.removePoint(gameId, "RED", PointsType.YUKO.name());
+
+    assertThat(storage.findById(KumiteGame.class, gameId).orElseThrow().getSenshu())
+        .as("RED did not score first after all")
+        .isEmpty();
+  }
+
+  @Test
+  void forfeit_onFinishedMatch_isRefused() {
+    String gameId = runningMatch();
+    service.disqualify(gameId, "RED");
+
+    assertThatThrownBy(() -> service.forfeit(gameId, "BLUE"))
+        .as("a decided match cannot be quietly forfeited")
+        .isInstanceOf(IllegalStateTransitionException.class);
+  }
+
+  @Test
+  void overrideWinner_appliedTwice_stillRecordsWhatTheEngineDecided() {
+    String gameId = runningMatch();
+    service.disqualify(gameId, "RED");
+
+    service.overrideWinner(gameId, new WinnerOverrideRequest("RED", "First call", "Referee One"));
+    GameWithFighters second =
+        service.overrideWinner(
+            gameId, new WinnerOverrideRequest("BLUE", "Corrected again", "Head Referee"));
+
+    assertThat(second.game().getRefereeOverride().orElseThrow().supersededOutcome())
+        .as("the engine's original result survives a second correction")
+        .isNotNull()
+        .satisfies(
+            engine -> {
+              assertThat(engine.reason()).isEqualTo(MatchEndReason.DISQUALIFICATION);
+              assertThat(engine.winner()).isEqualTo(PlayerColor.BLUE);
+            });
+  }
+
+  @Test
+  void addPoint_theFirstScoreOfTheMatch_recordsSenshu() {
+    String gameId = runningMatch();
+
+    service.addPoint(gameId, "BLUE", PointsType.YUKO.name());
+    service.addPoint(gameId, "RED", PointsType.YUKO.name());
+
+    KumiteGame stored = storage.findById(KumiteGame.class, gameId).orElseThrow();
+    assertThat(stored.getSenshu())
+        .as("SENSHU is the first to score, not the last")
+        .contains(PlayerColor.BLUE);
+  }
+
+  @Test
+  void addFoul_reachingTheFoulLimit_finishesTheMatch() {
+    String gameId = runningMatch();
+
+    GameWithFighters afterFourth = null;
+    for (int i = 0; i < TestGameProperties.FOULS_ENDING_MATCH; i++) {
+      afterFourth = service.addFoul(gameId, "BLUE");
+    }
+
+    assertThat(afterFourth).isNotNull();
+    assertThat(afterFourth.game().getGameState()).isEqualTo(GameState.FINISHED);
+    assertThat(afterFourth.game().getEndReason()).contains(MatchEndReason.FOUL_LIMIT);
+  }
+
+  /**
+   * The reversal decision (#70): a stage that carried a consequence cannot be walked back by
+   * removing the foul, because the consequence has already moved a score or ended the match.
+   */
+  @Test
+  void removeFoul_whenTheStageCarriedNoConsequence_isAllowed() {
+    String gameId = runningMatch();
+    service.addFoul(gameId, "BLUE");
+
+    GameWithFighters afterRemoval = service.removeFoul(gameId, "BLUE");
+
+    assertThat(afterRemoval.fighters().get(PlayerColor.BLUE).getFouls().getNumOfFouls()).isZero();
+  }
+
+  @Test
+  void disqualify_putsTheFighterOutAndAwardsTheMatchToTheOpponent() {
+    String gameId = runningMatch();
+
+    GameWithFighters afterDisqualification = service.disqualify(gameId, "RED");
+
+    assertThat(afterDisqualification.game().getGameState()).isEqualTo(GameState.FINISHED);
+    assertThat(afterDisqualification.game().getWinner()).isEqualTo(PlayerColor.BLUE);
+    assertThat(afterDisqualification.game().getEndReason())
+        .contains(MatchEndReason.DISQUALIFICATION);
+  }
+
+  @Test
+  void forfeit_awardsTheMatchToTheFighterWhoTurnedUp() {
+    String gameId = runningMatch();
+
+    GameWithFighters afterForfeit = service.forfeit(gameId, "BLUE");
+
+    assertThat(afterForfeit.game().getGameState()).isEqualTo(GameState.FINISHED);
+    assertThat(afterForfeit.game().getWinner()).isEqualTo(PlayerColor.RED);
+    assertThat(afterForfeit.game().getEndReason()).contains(MatchEndReason.KIKEN);
+  }
+
+  @Test
+  void overrideWinner_replacesTheResultAndKeepsWhatTheEngineDecided() {
+    String gameId = runningMatch();
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+    service.addPoint(gameId, "RED", PointsType.IPPON.name());
+
+    GameWithFighters overridden =
+        service.overrideWinner(
+            gameId,
+            new WinnerOverrideRequest("BLUE", "Scoring error on the third IPPON", "Head Referee"));
+
+    assertThat(overridden.game().getWinner()).isEqualTo(PlayerColor.BLUE);
+    assertThat(overridden.game().getEndReason()).contains(MatchEndReason.REFEREE_OVERRIDE);
+    assertThat(overridden.game().getRefereeOverride()).isPresent();
+    assertThat(overridden.game().getRefereeOverride().orElseThrow().supersededOutcome())
+        .as("what the engine decided is kept, not overwritten")
+        .isNotNull()
+        .satisfies(superseded -> assertThat(superseded.winner()).isEqualTo(PlayerColor.RED));
+  }
+
+  @Test
+  void overrideWinner_onAQueuedMatch_isRejected() {
+    String gameId = storage.save(KumiteGameBuilder.newGame().build()).getId();
+
+    assertThatThrownBy(
+            () ->
+                service.overrideWinner(
+                    gameId, new WinnerOverrideRequest("RED", "any reason", "Head Referee")))
+        .isInstanceOf(IllegalStateTransitionException.class);
+  }
+
+  @Test
+  void addPoint_afterAnOverride_doesNotLetTheEngineTakeTheResultBack() {
+    String gameId = runningMatch();
+    service.overrideWinner(
+        gameId, new WinnerOverrideRequest("BLUE", "Called on the mat", "Head Referee"));
+
+    assertThatThrownBy(() -> service.addPoint(gameId, "RED", PointsType.IPPON.name()))
+        .as("the match is finished, so scoring against it is refused")
+        .isInstanceOf(RuntimeException.class);
+
+    KumiteGame stored = storage.findById(KumiteGame.class, gameId).orElseThrow();
+    assertThat(stored.getWinner()).isEqualTo(PlayerColor.BLUE);
+    assertThat(stored.getEndReason()).contains(MatchEndReason.REFEREE_OVERRIDE);
+  }
+
+  @Test
+  void addTime_whileRunning_extendsTheClockAndRecordsWhoDidIt() {
+    String gameId =
+        storedMatch(
+            match ->
+                match.runningSince(LocalDateTime.now().minusSeconds(30), Duration.ofSeconds(120)));
+
+    GameWithFighters extended =
+        service.addTime(gameId, new ClockAdjustmentRequest(30, "Timekeeper"));
+
+    assertThat(extended.game().getRemainingTime())
+        .as("about 90s were left, and 30s were added")
+        .isBetween(Duration.ofSeconds(118), Duration.ofSeconds(121));
+    assertThat(extended.game().getClockAdjustments()).hasSize(1);
+    assertThat(extended.game().getClockAdjustments().get(0).addedBy()).isEqualTo("Timekeeper");
+  }
+
+  @Test
+  void addTime_whilePaused_extendsTheClockWithoutRestartingIt() {
+    String gameId = storedMatch(match -> match.pausedWithRemaining(Duration.ofSeconds(45)));
+
+    GameWithFighters extended =
+        service.addTime(gameId, new ClockAdjustmentRequest(10, "Timekeeper"));
+
+    assertThat(extended.game().getRemainingTime()).isEqualTo(Duration.ofSeconds(55));
+    assertThat(extended.game().getStartTime()).as("a paused clock stays paused").isNull();
+    assertThat(extended.game().getGameState()).isEqualTo(GameState.PAUSED);
+  }
+
+  @Test
+  void addTime_onFinishedMatch_isRejected() {
+    String gameId = storedMatch(KumiteGameBuilder::finished);
+
+    assertThatThrownBy(() -> service.addTime(gameId, new ClockAdjustmentRequest(10, "Timekeeper")))
+        .isInstanceOf(IllegalStateTransitionException.class);
+  }
+
+  @Test
+  void addTime_withIncrementThatIsNotOffered_isRejected() {
+    String gameId = runningMatch();
+
+    assertThatThrownBy(() -> service.addTime(gameId, new ClockAdjustmentRequest(7, "Timekeeper")))
+        .isInstanceOf(InvalidGameRequestException.class)
+        .hasMessageContaining("increments");
+  }
+
+  /** A running match whose fighters are stored, so scoring behaves as production does. */
+  private String runningMatch() {
+    return storedMatch(match -> match.runningSince(LocalDateTime.now(), Duration.ofSeconds(120)));
+  }
+
+  /**
+   * Stores two fighters and a match referring to them.
+   *
+   * <p>The fighters have to exist in storage: since #49 the match holds only their ids, so a
+   * fixture that builds a match without saving its fighters describes a match whose fighters cannot
+   * be loaded.
+   */
+  private String storedMatch(UnaryOperator<KumiteGameBuilder> customise) {
+    Player red = storage.save(PlayerBuilder.newPlayer().named("Kenji").build());
+    Player blue = storage.save(PlayerBuilder.newPlayer().named("Sato").build());
+    KumiteGameBuilder match =
+        KumiteGameBuilder.newGame().with(PlayerColor.RED, red).with(PlayerColor.BLUE, blue);
+    return storage.save(customise.apply(match).build()).getId();
+  }
+}

--- a/src/test/java/com/management/rules/MatchEndConditionTest.java
+++ b/src/test/java/com/management/rules/MatchEndConditionTest.java
@@ -1,0 +1,136 @@
+package com.management.rules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import com.management.enums.PointsType;
+import com.management.models.GameWithFighters;
+import com.management.rules.conditions.DisqualificationCondition;
+import com.management.rules.conditions.FoulLimitCondition;
+import com.management.rules.conditions.PointsThresholdCondition;
+import com.management.rules.conditions.TimeExpiredCondition;
+import com.management.testsupport.KumiteGameBuilder;
+import com.management.testsupport.PlayerBuilder;
+import com.management.testsupport.TestGameProperties;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One test class per condition would be four files of three lines each; they are grouped here
+ * because each condition is a single predicate and the interesting part is the boundary — one point
+ * short, exactly at, one past.
+ */
+class MatchEndConditionTest {
+
+  private final PointsThresholdCondition pointsThreshold =
+      new PointsThresholdCondition(TestGameProperties.standard());
+  private final FoulLimitCondition foulLimit =
+      new FoulLimitCondition(TestGameProperties.standard());
+  private final TimeExpiredCondition timeExpired = new TimeExpiredCondition();
+  private final DisqualificationCondition disqualification = new DisqualificationCondition();
+
+  @Test
+  void pointsThreshold_belowTheWinningScore_doesNotEndTheMatch() {
+    GameWithFighters match = matchWhereRedHasScored(PointsType.WAZARI, 3);
+
+    assertThat(match.fighters().get(PlayerColor.RED).getPoints().getNumOfPoints()).isEqualTo(6);
+    assertThat(pointsThreshold.evaluate(match)).isEmpty();
+  }
+
+  @Test
+  void pointsThreshold_exactlyAtTheWinningScore_endsTheMatch() {
+    GameWithFighters match = matchWhereRedHasScored(PointsType.WAZARI, 4);
+
+    assertThat(pointsThreshold.evaluate(match)).contains(MatchEndReason.POINTS_THRESHOLD);
+  }
+
+  /** Crossing, not landing on: the score is never clamped to the threshold. */
+  @Test
+  void pointsThreshold_whenTheScoreOvershoots_endsTheMatchAndKeepsTheMargin() {
+    GameWithFighters match = matchWhereRedHasScored(PointsType.IPPON, 4);
+
+    assertThat(pointsThreshold.evaluate(match)).contains(MatchEndReason.POINTS_THRESHOLD);
+    assertThat(match.fighters().get(PlayerColor.RED).getPoints().getNumOfPoints())
+        .as("12 points stands; the threshold triggers the end, it does not cap the score")
+        .isEqualTo(12);
+  }
+
+  @Test
+  void foulLimit_belowTheLimit_doesNotEndTheMatch() {
+    assertThat(foulLimit.evaluate(matchWhereBlueHasFouled(3))).isEmpty();
+  }
+
+  @Test
+  void foulLimit_atTheLimit_endsTheMatch() {
+    assertThat(foulLimit.evaluate(matchWhereBlueHasFouled(4))).contains(MatchEndReason.FOUL_LIMIT);
+  }
+
+  @Test
+  void timeExpired_whileTimeRemains_doesNotEndTheMatch() {
+    GameWithFighters running =
+        KumiteGameBuilder.newGame()
+            .runningSince(LocalDateTime.now(), Duration.ofSeconds(30))
+            .buildWithFighters();
+
+    assertThat(timeExpired.evaluate(running)).isEmpty();
+  }
+
+  @Test
+  void timeExpired_whenTheClockHasRunOut_endsTheMatch() {
+    GameWithFighters expired =
+        KumiteGameBuilder.newGame()
+            .runningSince(LocalDateTime.now().minusMinutes(5), Duration.ofSeconds(30))
+            .buildWithFighters();
+
+    assertThat(timeExpired.evaluate(expired)).contains(MatchEndReason.TIME_EXPIRED);
+  }
+
+  /** A paused clock is not counting, so it cannot expire. */
+  @Test
+  void timeExpired_whenTheMatchIsPaused_doesNotEndTheMatch() {
+    GameWithFighters paused =
+        KumiteGameBuilder.newGame().pausedWithRemaining(Duration.ZERO).buildWithFighters();
+
+    assertThat(timeExpired.evaluate(paused)).isEmpty();
+  }
+
+  @Test
+  void disqualification_whenNobodyIsOut_doesNotEndTheMatch() {
+    assertThat(disqualification.evaluate(KumiteGameBuilder.newGame().buildWithFighters()))
+        .isEmpty();
+  }
+
+  @Test
+  void disqualification_whenFighterIsOut_endsTheMatch() {
+    GameWithFighters match = KumiteGameBuilder.newGame().buildWithFighters();
+    match.fighters().get(PlayerColor.BLUE).disqualify();
+
+    assertThat(disqualification.evaluate(match)).contains(MatchEndReason.DISQUALIFICATION);
+  }
+
+  private static GameWithFighters matchWhereRedHasScored(PointsType type, int times) {
+    return KumiteGameBuilder.newGame()
+        .with(
+            PlayerColor.RED,
+            PlayerBuilder.newPlayer()
+                .alreadyPersistedAs("red-1")
+                .named("Kenji")
+                .scoring(type, times)
+                .build())
+        .buildWithFighters();
+  }
+
+  private static GameWithFighters matchWhereBlueHasFouled(int fouls) {
+    return KumiteGameBuilder.newGame()
+        .with(
+            PlayerColor.BLUE,
+            PlayerBuilder.newPlayer()
+                .alreadyPersistedAs("blue-1")
+                .named("Sato")
+                .withFouls(fouls)
+                .build())
+        .buildWithFighters();
+  }
+}

--- a/src/test/java/com/management/rules/MatchOutcomeEvaluatorTest.java
+++ b/src/test/java/com/management/rules/MatchOutcomeEvaluatorTest.java
@@ -1,0 +1,172 @@
+package com.management.rules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.management.enums.MatchEndReason;
+import com.management.enums.PlayerColor;
+import com.management.enums.PointsType;
+import com.management.models.GameWithFighters;
+import com.management.models.MatchOutcome;
+import com.management.testsupport.KumiteGameBuilder;
+import com.management.testsupport.PlayerBuilder;
+import com.management.testsupport.TestRulesEngine;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The rules engine assembled as the container assembles it, but constructed with {@code new}.
+ *
+ * <p>The wiring comes from {@link TestRulesEngine} rather than being restated here, because the
+ * order is the thing under test: this class used to build its own list in a different order from
+ * the production {@code @Order} values, so every scenario below confirmed a priority the
+ * application did not actually have. One source for the order means a change to it shows up as a
+ * failing assertion on {@code decidedBy}.
+ */
+class MatchOutcomeEvaluatorTest {
+
+  private final MatchOutcomeEvaluator evaluator = TestRulesEngine.standard();
+
+  @Test
+  void evaluate_whileTheMatchIsBeingFought_findsNoOutcome() {
+    GameWithFighters match =
+        KumiteGameBuilder.newGame()
+            .runningSince(LocalDateTime.now(), Duration.ofSeconds(60))
+            .buildWithFighters();
+
+    assertThat(evaluator.evaluate(match)).isEmpty();
+  }
+
+  @Test
+  void evaluate_whenFighterCrossesTheThreshold_theyWinOnPoints() {
+    GameWithFighters match =
+        running().with(PlayerColor.RED, scorer(PointsType.IPPON, 3)).buildWithFighters();
+
+    Optional<MatchOutcome> outcome = evaluator.evaluate(match);
+
+    assertThat(outcome).isPresent();
+    assertThat(outcome.get().winner()).isEqualTo(PlayerColor.RED);
+    assertThat(outcome.get().reason()).isEqualTo(MatchEndReason.POINTS_THRESHOLD);
+    assertThat(outcome.get().decidedBy()).isEqualTo("HighestScoreWinnerRule");
+  }
+
+  @Test
+  void evaluate_whenFighterReachesTheFoulLimit_theOpponentWins() {
+    GameWithFighters match =
+        running()
+            .with(
+                PlayerColor.BLUE,
+                PlayerBuilder.newPlayer().alreadyPersistedAs("blue-1").withFouls(4).build())
+            .buildWithFighters();
+
+    Optional<MatchOutcome> outcome = evaluator.evaluate(match);
+
+    assertThat(outcome).isPresent();
+    assertThat(outcome.get().reason()).isEqualTo(MatchEndReason.FOUL_LIMIT);
+    assertThat(outcome.get().winner()).isEqualTo(PlayerColor.RED);
+    assertThat(outcome.get().decidedBy()).isEqualTo("FoulLimitWinnerRule");
+  }
+
+  /**
+   * The rule this exists to prevent: the score used to decide a foul-limit ending, so a fighter who
+   * was ahead could foul out and still win — a penalty that rewards the fighter it penalises.
+   */
+  @Test
+  void evaluate_whenTheLeaderFoulsOut_theyDoNotWinOnTheirOwnFoul() {
+    GameWithFighters match =
+        running()
+            .with(
+                PlayerColor.BLUE,
+                PlayerBuilder.newPlayer()
+                    .alreadyPersistedAs("blue-1")
+                    .scoring(PointsType.IPPON)
+                    .withFouls(4)
+                    .build())
+            .buildWithFighters();
+
+    Optional<MatchOutcome> outcome = evaluator.evaluate(match);
+
+    assertThat(outcome).isPresent();
+    assertThat(outcome.get().winner())
+        .as("BLUE leads 3-0 and fouls out; the match goes to RED")
+        .isEqualTo(PlayerColor.RED);
+  }
+
+  /** Disqualification outranks the score: a fighter who is out cannot win on points. */
+  @Test
+  void evaluate_whenTheLeaderIsDisqualified_theOpponentWins() {
+    GameWithFighters match =
+        running().with(PlayerColor.RED, scorer(PointsType.IPPON, 1)).buildWithFighters();
+    match.fighters().get(PlayerColor.RED).disqualify();
+
+    Optional<MatchOutcome> outcome = evaluator.evaluate(match);
+
+    assertThat(outcome).isPresent();
+    assertThat(outcome.get().winner()).isEqualTo(PlayerColor.BLUE);
+    assertThat(outcome.get().reason()).isEqualTo(MatchEndReason.DISQUALIFICATION);
+    assertThat(outcome.get().decidedBy()).isEqualTo("DisqualificationWinnerRule");
+  }
+
+  @Test
+  void evaluate_whenTimeExpiresWithLevelScores_senshuDecidesIt() {
+    GameWithFighters match =
+        KumiteGameBuilder.newGame()
+            .runningSince(LocalDateTime.now().minusMinutes(5), Duration.ofSeconds(30))
+            .firstScorer(PlayerColor.BLUE)
+            .with(PlayerColor.RED, scorer(PointsType.YUKO, 1))
+            .with(
+                PlayerColor.BLUE,
+                PlayerBuilder.newPlayer()
+                    .alreadyPersistedAs("blue-1")
+                    .scoring(PointsType.YUKO, 1)
+                    .build())
+            .buildWithFighters();
+
+    Optional<MatchOutcome> outcome = evaluator.evaluate(match);
+
+    assertThat(outcome).isPresent();
+    assertThat(outcome.get().winner()).isEqualTo(PlayerColor.BLUE);
+    assertThat(outcome.get().reason()).isEqualTo(MatchEndReason.TIME_EXPIRED);
+    assertThat(outcome.get().decidedBy()).isEqualTo("SenshuWinnerRule");
+  }
+
+  @Test
+  void evaluate_whenTimeExpiresWithNobodyHavingScored_isDrawn() {
+    GameWithFighters match =
+        KumiteGameBuilder.newGame()
+            .runningSince(LocalDateTime.now().minusMinutes(5), Duration.ofSeconds(30))
+            .buildWithFighters();
+
+    Optional<MatchOutcome> outcome = evaluator.evaluate(match);
+
+    assertThat(outcome).isPresent();
+    assertThat(outcome.get().winner()).as("a draw is a result, not a missing one").isNull();
+    assertThat(outcome.get().decidedBy()).isEqualTo("DrawWinnerRule");
+  }
+
+  @Test
+  void evaluate_onMatchThatHasAlreadyFinished_findsNothingToChange() {
+    GameWithFighters finished =
+        KumiteGameBuilder.newGame()
+            .finished()
+            .with(PlayerColor.RED, scorer(PointsType.IPPON, 3))
+            .buildWithFighters();
+
+    assertThat(evaluator.evaluate(finished))
+        .as("the first result stands; re-evaluating must never rewrite it")
+        .isEmpty();
+  }
+
+  private static KumiteGameBuilder running() {
+    return KumiteGameBuilder.newGame().runningSince(LocalDateTime.now(), Duration.ofSeconds(60));
+  }
+
+  private static com.management.models.Player scorer(PointsType type, int times) {
+    return PlayerBuilder.newPlayer()
+        .alreadyPersistedAs("red-1")
+        .named("Kenji")
+        .scoring(type, times)
+        .build();
+  }
+}

--- a/src/test/java/com/management/testsupport/KumiteGameBuilder.java
+++ b/src/test/java/com/management/testsupport/KumiteGameBuilder.java
@@ -56,6 +56,7 @@ public final class KumiteGameBuilder {
   @Nullable private Duration remainingTime;
   @Nullable private LocalDateTime startTime;
   @Nullable private PlayerColor winner;
+  @Nullable private PlayerColor senshu;
   @Nullable private String id;
 
   private KumiteGameBuilder() {
@@ -138,6 +139,12 @@ public final class KumiteGameBuilder {
     return this;
   }
 
+  /** A match in which the given colour scored first — the SENSHU tiebreak's input. */
+  public KumiteGameBuilder firstScorer(PlayerColor color) {
+    this.senshu = color;
+    return this;
+  }
+
   /**
    * Gives the match a persistent identifier, as though it had been saved.
    *
@@ -189,6 +196,9 @@ public final class KumiteGameBuilder {
     }
     game.setStartTime(startTime);
     game.setWinner(winner);
+    if (senshu != null) {
+      game.recordFirstScorer(senshu);
+    }
     if (id != null) {
       ReflectionTestUtils.setField(game, "id", id);
     }

--- a/src/test/java/com/management/testsupport/TestGameProperties.java
+++ b/src/test/java/com/management/testsupport/TestGameProperties.java
@@ -13,8 +13,15 @@ public final class TestGameProperties {
 
   private TestGameProperties() {}
 
+  public static final int WINNING_POINTS = 8;
+  public static final int FOULS_ENDING_MATCH = 4;
+
   public static GameProperties standard() {
     return new GameProperties(
-        Duration.ofSeconds(120), List.of(Duration.ofSeconds(90), Duration.ofSeconds(180)));
+        Duration.ofSeconds(120),
+        List.of(Duration.ofSeconds(90), Duration.ofSeconds(180)),
+        WINNING_POINTS,
+        FOULS_ENDING_MATCH,
+        List.of(Duration.ofSeconds(10), Duration.ofSeconds(30)));
   }
 }

--- a/src/test/java/com/management/testsupport/TestRulesEngine.java
+++ b/src/test/java/com/management/testsupport/TestRulesEngine.java
@@ -1,0 +1,44 @@
+package com.management.testsupport;
+
+import com.management.rules.MatchOutcomeEvaluator;
+import com.management.rules.conditions.DisqualificationCondition;
+import com.management.rules.conditions.FoulLimitCondition;
+import com.management.rules.conditions.PointsThresholdCondition;
+import com.management.rules.conditions.TimeExpiredCondition;
+import com.management.rules.winners.DisqualificationWinnerRule;
+import com.management.rules.winners.DrawWinnerRule;
+import com.management.rules.winners.FoulLimitWinnerRule;
+import com.management.rules.winners.HighestScoreWinnerRule;
+import com.management.rules.winners.SenshuWinnerRule;
+import java.util.List;
+
+/**
+ * The rules engine wired the way the container wires it, for tests that construct services with
+ * {@code new}.
+ *
+ * <p><strong>Both lists are in {@code @Order} order, and that is load-bearing.</strong> The
+ * container sorts by the annotation; this class cannot, so the order is written out by hand. An
+ * earlier version listed the conditions in a different order from the annotations, which meant
+ * every test agreed on a priority the application did not have. If a rule's {@code @Order} changes,
+ * change it here in the same commit — {@code MatchOutcomeEvaluatorTest} asserts which rule decided,
+ * so a mismatch shows up as a failing assertion rather than as silence.
+ */
+public final class TestRulesEngine {
+
+  private TestRulesEngine() {}
+
+  public static MatchOutcomeEvaluator standard() {
+    return new MatchOutcomeEvaluator(
+        List.of(
+            new DisqualificationCondition(),
+            new FoulLimitCondition(TestGameProperties.standard()),
+            new PointsThresholdCondition(TestGameProperties.standard()),
+            new TimeExpiredCondition()),
+        List.of(
+            new DisqualificationWinnerRule(),
+            new FoulLimitWinnerRule(TestGameProperties.standard()),
+            new HighestScoreWinnerRule(),
+            new SenshuWinnerRule(),
+            new DrawWinnerRule()));
+  }
+}


### PR DESCRIPTION
Closes #69, closes #70, closes #71, closes #72, closes #73, closes #74. Completes epic #68.

## What this does

A match now ends on its own and produces a correct, explained result. This is the component the docs have been calling the Game Orchestrator, built the way the epic requires: **every rule is a separate registered unit, and adding one changes no existing file.**

### The engine (#71, #72)

`com.management.rules` holds two interfaces and eight implementations:

- **`MatchEndCondition`** — *is the match over, and why.* `PointsThresholdCondition`, `FoulLimitCondition`, `TimeExpiredCondition`, `DisqualificationCondition`.
- **`WinnerRule`** — *who won*, evaluated in `@Order` priority until one answers: disqualification (10) → highest score (20) → SENSHU (30) → draw (`MAX_VALUE`).

`MatchOutcomeEvaluator` takes both lists **injected by the container**, so a new rule is a new `@Component` and nothing else. It is pure — it decides, it never writes — which is what lets it be tested with `new` and no container, and keeps ordering and persistence decided in one place. `KumiteGameService` calls it after every point, foul and disqualification, then applies and persists the answer.

- **SENSHU is captured as it happens**, on the first score, because it cannot be reconstructed afterwards.
- **Ending is idempotent**: `applyOutcome` no-ops on a finished match, so two conditions true in the same instant cannot rewrite each other's result.
- **The reason is recorded** (`MatchEndReason`) along with the rule that decided it, and the response now carries `endReason` and `overridden`.
- **A draw is a real outcome**, not a missing one — `DrawWinnerRule` always answers, so the search is total.

### Configuration (#69)

`GameProperties` grew `winning-points` (8), `fouls-ending-match` (4) and `clock-increments` (10s, 30s). No rule value appears in code. A test supplies its own threshold and the behaviour changes with no code change.

**The threshold is a trigger, not a cap** — a fighter on 7 who lands an IPPON finishes on 10 and the margin is kept; a test asserts the score is *not* clamped.

**Per-championship question, answered:** the threshold stays in application configuration for now, and becomes the *default* when the championship layer exists. Putting it on a championship record today would mean building that record before anything reads it.

### Fouls (#70)

`FoulTypes` is no longer dead: the stage is **derived** from the count (`FoulTypes.forCount`), never stored, so the two cannot disagree. `HANSOKU` carries its opponent award as enum data, `SHIKKAKU` is disqualifying, and reaching an awarding stage hands the points to the opponent **through the ordinary scoring path** — the same versioned, retried write a referee's award takes — rather than mutating the other fighter directly.

**Reversal decision, made explicitly:** removing a foul is allowed while the fighter's stage carried no consequence, and **refused with 409** once it did. Unwinding a point that the opponent has since built on, or a disqualification that already ended the match, is guesswork; the referee's route is an override, which records why.

### Operator actions (#73, #74)

- `PUT /{gameId}/disqualify/{color}` and `PUT /{gameId}/kiken/{color}` — both operator-initiated, since no condition can detect an absence.
- `PUT /{gameId}/override-winner` — **the reason is required by a constraint**, not a service check, so an unjustified override is refused at the boundary. The override records winner, reason, decider and timestamp, **keeps what the engine had decided** in `supersededOutcome`, and the engine will not overwrite it afterwards. Allowed on a started match (including a finished one — correcting a decided result is the point); refused on a QUEUED match.
- `PUT /{gameId}/add-time` — accepts any configured increment; the clock banks elapsed time and restarts before adding, which is the case most likely to be got wrong, tested both running and paused. Refused on a finished match. Every addition is recorded with amount, time and actor.

**Actor fields are caller-supplied names**, as agreed, and are the exact field the security epic (#81) will fill from an authenticated identity — the shape does not change, only where the value comes from.

## Fixed in self-review, before commit

The review found ten issues; nine are fixed here, and each got a test.

- **Two clock bugs, same shape.** `applyOutcome` and `applyOverride` both nulled `startTime` *before* calling `getTimer()` — and the timer rebuilds itself from that field, so it was constructed as a clock that had never started and reported the match's **full** duration. An eight-point finish 30 seconds into a 120-second match recorded `remainingSeconds: 120`, which is precisely what `stopAndReport` exists to prevent. Both now read the clock first.
- **A fighter could win by fouling out.** `FoulLimitCondition` ended the match and the *score* then decided it, so leading 3–0 and committing your fourth foul won you the bout. New `FoulLimitWinnerRule` (order 15) awards it to the opponent, mirroring disqualification. A penalty that rewards the penalised fighter is not a penalty.
- **Condition priority was whatever the classpath scan produced.** The four `MatchEndCondition` beans had no `@Order` while the winner rules all did — and more than one condition is routinely true at once. They now declare 10/20/30/40 (disqualification, foul limit, points, time), most-specific first.
- **The tests were pinning a priority the app didn't have.** `MatchOutcomeEvaluatorTest` built its own rule list in a *different* order from the annotations. Both it and the service tests now take the wiring from `TestRulesEngine`, so there is one source for the order and a drift shows up as a failing `decidedBy` assertion.
- **A point landing after the clock ran out was counted.** Expiry is observed rather than pushed, so the match was still `RUNNING`; the late point was written to the fighter and only *then* did the evaluator notice, turning a draw into a win. Scoring now settles the expired match and refuses the event with 409.
- **SENSHU survived having its point removed.** A mistakenly-awarded point that was then corrected away left a phantom first-scorer that could decide a level match at expiry, for a fighter who never scored first. Removing a point that returns the holder to zero now clears it.
- **KIKEN on a finished match silently did nothing** — returned 200 with the stale result and an ignored forfeit, where `disqualify` in the same position returns 409. `forfeit` now has the same guard as its siblings.
- **A second override destroyed the engine's original verdict**, recording the *first override* as the superseded outcome — losing the one thing the record exists to keep. It now carries the engine's result through any number of corrections.
- Plus a stale duplicated javadoc block on `settle`, and holes in the `OptionalAsField` regex I tightened earlier (it couldn't see nested generics or formatter-wrapped declarations).

## Decisions and findings worth your attention

1. **The foul progression as specified does not fit one sequence.** #70 says "CHUI up to 3, then HANSOKU CHUI after 3 CHUI" *and* "accumulating 4 fouls ends the match" — but under that reading the 4th foul is HANSOKU_CHUI, a warning, so HANSOKU's point award is never reached by accumulation. I did **not** pick between them: the stage order and the ending limit are both configuration, so raising `game.fouls-ending-match` to 5 activates HANSOKU's award without a code change. Flagged in CLAUDE.md as needing your decision.
2. **A quality-gate rule was broken and is fixed here.** The project's own `OptionalAsField` check matched any *method returning* `Optional` — the one use `java.md` prescribes, and which `java.md`'s own worked example contains. It was mechanically pushing authors towards returning `null`. The regex now requires a field's tail (`=` or `;`). Baseline unchanged at 3.
3. **Scoring a finished match is now refused (409).** It was silently allowed; the score would move while the recorded result stood still, leaving two answers with no indication which was authoritative.
4. **SENSHU capture made the match document a contention point**, which the concurrency IT caught immediately — six simultaneous first-scores all tried to claim it and five got 409s. Fixed with `MatchStateWriter`, a small retried bean for write-once match facts (a separate bean because `@Retryable` is proxy-applied and a self-call would bypass it). An ordinary mid-match point still writes one document.
5. **Time expiry is observed, not pushed** — noticed on the next scoring event, so a match left untouched past its duration stays open. The epic says to note this rather than build a scheduler; recorded in CLAUDE.md under what is not built.

## Verification

`mvn verify` green: **152** fast-suite tests, 13 integration tests, coverage floor met, both checkstyle ratchets respected (10/17 and 3/3).

Tests cover every ending condition at its boundary, every winner rule including the draw and the SENSHU tiebreak, and the whole engine driven through the service across a save-and-reload boundary: threshold finish, foul-limit finish (including the leader fouling out), disqualification, KIKEN, override precedence and double-override, late-point rejection, SENSHU lapse, and add-time while running and while paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
