### PR TITLE
Drop the stale wiki-vocabulary note (#62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,6 @@ Winner priority: disqualification → higher score → SENSHU → draw. **SENSHU
 - `PointsType.WAZARI` is missing the hyphen of the WKF's **WAZA-ARI**. It is public API surface — clients send `pointType=WAZARI`. #102 renamed `YOKO` to `YUKO` on the same grounds, so this is the last spelling left out of step with the rulebook.
 - `PlayerColor` has only `RED` / `BLUE`; the AKA/AO names appear nowhere in code.
 - `FoulTypes` is now derived from the foul count (`FoulTypes.forCount`). With the default limit of 4 the match ends at `HANSOKU_CHUI`, so `HANSOKU`'s point award and `SHIKKAKU`'s disqualification are only reached by accumulation if the limit is raised — the two rules the issues state ("CHUI up to 3, then HANSOKU CHUI" and "4 fouls ends the match") do not both fit one progression. Both are expressed as configuration rather than picked between in code. **Worth an explicit decision.**
-- The project wiki calls the in-progress state `STARTED`; the code says `RUNNING`. **The code is authoritative.**
 
 ## Stack
 


### PR DESCRIPTION
Closes #62.

The last confirmed inaccuracy from #62. The note claimed the project wiki calls the in-progress match state `STARTED` while the code says `RUNNING` — checked against the wiki today, and the only occurrences of "started" on any page are ordinary prose ("When the game is started, a countdown..."). There is no divergence left to record.

The rest of #62 was resolved across this run rather than in one change:

- The `calculatePoints` reference is gone — zero matches in `CLAUDE.md`.
- `.claude/docs/` no longer exists, so the `GameConfig` description in `patterns.md` went with it; `GameConfig` itself was deleted by #42 and replaced with `GameProperties`.
- `CLAUDE.md` was rewritten alongside each of the five epics, so the endpoint list, class responsibilities and state machine describe the merged code.
- The GitHub wiki now carries a **Backend Status** page auditing what is built against the rules page, including seven places where the two disagree.

One acceptance criterion is deliberately not met: the convention for keeping documentation current was to live in `.claude/docs/working-rules.md`, and that file no longer exists. Worth reopening as its own issue if you want the convention written down somewhere that does.